### PR TITLE
Fix Fortran build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ARG fmask_version=0.5.7
 
 COPY deployment/create-conda-environment.sh deployment/environment.yaml ./
 RUN --mount=type=cache,target=/opt/conda/pkgs,id=conda \
-    --mount=type=cache,target=/root/.cache,id=pip \
+    --mount=type=cache,target=/root/.cache,id=pipconda \
     ./create-conda-environment.sh /opt/conda
 
 # Use conda for the remaining commands
@@ -54,7 +54,7 @@ COPY wagl ./wagl
 COPY .git ./.git
 COPY pyproject.toml meson.build LICENCE.md README.md ./
 
-RUN --mount=type=cache,target=/root/.cache,id=pip \
+RUN --mount=type=cache,target=/root/.cache,id=pipours \
     --mount=type=tmpfs,target=/tmp <<EOF
     pip install --config-settings=builddir=/tmp/ard-pipeline-build .
 EOF

--- a/Justfile
+++ b/Justfile
@@ -12,6 +12,9 @@
 @build:
     docker build --platform linux/amd64 -t ard:dev .
 
+@build-plain:
+    docker build --progress=plain --platform linux/amd64 -t ard:dev .
+
 @build-builder:
     docker build --platform linux/amd64 --target builder -t ard:builder .
 

--- a/deployment/create-conda-environment.sh
+++ b/deployment/create-conda-environment.sh
@@ -48,7 +48,8 @@ set +ux
 # shellcheck source=/dev/null
 . "${location}/bin/activate"
 
-conda env update -n base -f "$(dirname "$0")/environment.yaml"
+conda install -c conda-forge -n base mamba
+mamba env update -n base -f "$(dirname "$0")/environment.yaml"
 
 # Freeze the environment as it exists without our locally-installed  packages.
 # conda env export --from-history  > "${location}/environment.yaml"

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,6 @@ py3 = py_mod.find_installation(pure: false)
 
 py3_dep = py3.dependency()
 
-add_languages('fortran', native: false)
 ff = meson.get_compiler('fortran')
 
 c = run_command('utils/python-package-files.sh', check: true)

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,8 @@ py_mod = import('python')
 py3 = py_mod.find_installation(pure: false)
 
 py3_dep = py3.dependency()
+
+add_languages('fortran', native: false)
 ff = meson.get_compiler('fortran')
 
 c = run_command('utils/python-package-files.sh', check: true)
@@ -22,14 +24,15 @@ py3.install_sources(
     preserve_path: true,
 )
 
-fortran_args = ff.get_supported_arguments(
-    ff.get_supported_arguments('-Wno-argument-mismatch'),
-    ff.get_supported_arguments('-Wno-conversion'),
-    ff.get_supported_arguments('-Wno-maybe-uninitialized'),
-    ff.get_supported_arguments('-Wno-unused-dummy-argument'),
-    ff.get_supported_arguments('-Wno-unused-label'),
-    ff.get_supported_arguments('-Wno-unused-variable'),
-    ff.get_supported_arguments('-Wno-tabs'),
+add_project_arguments(
+    '-Wno-argument-mismatch',
+    '-Wno-conversion',
+    '-Wno-maybe-uninitialized',
+    '-Wno-unused-dummy-argument',
+    '-Wno-unused-label',
+    '-Wno-unused-variable',
+    '-Wno-tabs',
+    language: 'fortran',
 )
 
 

--- a/wagl/f90_sources/cast_shadow_main.f90
+++ b/wagl/f90_sources/cast_shadow_main.f90
@@ -111,8 +111,8 @@ SUBROUTINE cast_shadow_main( &
     real*4 sun_zen
     real*4 htol
     logical exists
-    real pi, r2d, d2r, eps
-    common/base/pi,r2d,d2r,eps
+    real pi_real, r2d_real, d2r_real, eps_real
+    common/base/pi_real,r2d_real,d2r_real,eps_real
 
 !f2py intent(in) dem_data, solar_data, sazi_data
 !f2py intent(in) dresx, dresy, spheroid, alat1, alon1
@@ -127,10 +127,10 @@ SUBROUTINE cast_shadow_main( &
 !f2py intent(out) mask_all
 
 !   set basic constants
-    pi=4.0*atan(1.0)
-    r2d=180.0/pi
-    d2r=pi/180.0
-    eps=1.0e-7
+    pi_real=4.0*atan(1.0)
+    r2d_real=180.0/pi_real
+    d2r_real=pi_real/180.0
+    eps_real=1.0e-7
 
 !   set the tolerance for occlusion in metres
 !   (usually >0 and less than 10.0m)

--- a/wagl/f90_sources/cast_shadow_mask.f90
+++ b/wagl/f90_sources/cast_shadow_mask.f90
@@ -20,8 +20,6 @@ SUBROUTINE get_proj_shadows(hx, hy, ns, nl, &
     integer*2 mask(nlA_ori, nsA_ori)
     integer*2 rmax, rmin
 
-    real pi,r2d,d2r,eps
-    common/base/pi,r2d,d2r,eps
 !
 !   calculate the border info for the sun position
 !   In Australia and in the south in particular case=1

--- a/wagl/f90_sources/terrain_border_margins.f90
+++ b/wagl/f90_sources/terrain_border_margins.f90
@@ -13,8 +13,8 @@ SUBROUTINE set_borderf(set_border,phi_sun, zmax, zmin, sun_zen, hx, hy, &
     real phi_sun, zmax, zmin, sun_zen, phc
     real*8 hx, hy
     real sinphc, cosphc, d, d0
-    real pi, r2d, d2r, eps
-    common/base/pi,r2d,d2r,eps
+    real pi_real, d2r_real
+    common/base/pi_real,d2r_real
     logical set_border
 
 
@@ -27,16 +27,16 @@ SUBROUTINE set_borderf(set_border,phi_sun, zmax, zmin, sun_zen, hx, hy, &
 
     if (phi_sun.ge.0.0 .and. phi_sun.le.90.0) then
         az_case=1
-        phc=pi/2.0-phi_sun*d2r
+        phc=pi_real/2.0-phi_sun*d2r_real
     else if (phi_sun.ge.270.0 .and. phi_sun.le.360.0) then
         az_case=2
-        phc=phi_sun*d2r-3.0*pi/2.0
+        phc=phi_sun*d2r_real-3.0*pi_real/2.0
     else if (phi_sun.ge.180.0 .and. phi_sun.le.270.0) then
         az_case=3
-        phc=3.0*pi/2.0-phi_sun*d2r
+        phc=3.0*pi_real/2.0-phi_sun*d2r_real
     else if (phi_sun.ge.90.0 .and. phi_sun.le.180.0) then
         az_case=4
-        phc=phi_sun*d2r-pi/2.0
+        phc=phi_sun*d2r_real-pi_real/2.0
     else
         ierr=61
         goto 99
@@ -53,7 +53,7 @@ SUBROUTINE set_borderf(set_border,phi_sun, zmax, zmin, sun_zen, hx, hy, &
 !   distance in the sun direction is at Zmax
 !   then it can just occlude the first pixel
 !
-    d = (zmax-zmin)/tan(pi/2.0-sun_zen*d2r)
+    d = (zmax-zmin)/tan(pi_real/2.0-sun_zen*d2r_real)
     if(cosphc*hy.gt.sinphc*hx) then
         d0 = 0.5*hx/cosphc
     else
@@ -89,7 +89,7 @@ SUBROUTINE set_borderf(set_border,phi_sun, zmax, zmin, sun_zen, hx, hy, &
         else
             m_inc(k)=-h_offset(k)*sinphc/hy
         endif
-        h_offset(k)=h_offset(k)*tan(pi/2.0-sun_zen*d2r)
+        h_offset(k)=h_offset(k)*tan(pi_real/2.0-sun_zen*d2r_real)
     enddo
 
 !   n_add and m_add are the sizes of the pixel buffer

--- a/wagl/f90_sources/terrain_occlusion.f90
+++ b/wagl/f90_sources/terrain_occlusion.f90
@@ -27,8 +27,6 @@ SUBROUTINE proj_terrain(n_max, m_max, n, m, z, mask, n_off, m_off, k_max, &
     real zmax, t, tt, test, htol, xd, yd, zpos
     integer i, j, ii, jj, k, ipos, jpos
     integer*4 itot
-    real pi,r2d,d2r,eps
-    common/base/pi,r2d,d2r,eps
 
 !   loop over object matrix A and project out into buffer
 

--- a/wagl/meson.build
+++ b/wagl/meson.build
@@ -110,6 +110,7 @@ _cast_shadow_mask = py3.extension_module(
     link_language: 'fortran',
     subdir: 'wagl',
 )
+
 exiting_angle_src = [
     'f90_sources/sys_variables.f90',
     'f90_sources/exiting_angle.f90',
@@ -136,7 +137,7 @@ _exiting_angle = py3.extension_module(
         _exiting_angle_module,
         exiting_angle_src,
     ],
-    fortran_args: fortran_args,
+
     install: true,
     dependencies: [fortranobject_dep],
     link_language: 'fortran',
@@ -167,7 +168,7 @@ _incident_angle = py3.extension_module(
         _incident_angle_module,
         incident_angle_src,
     ],
-    fortran_args: fortran_args,
+
     install: true,
     dependencies: [fortranobject_dep],
     link_language: 'fortran',
@@ -199,7 +200,7 @@ _slope_aspect = py3.extension_module(
         _slope_aspect_module,
         slope_aspect_src,
     ],
-    fortran_args: fortran_args,
+
     install: true,
     dependencies: [fortranobject_dep],
     link_language: 'fortran',
@@ -232,7 +233,7 @@ _surface_reflectance = py3.extension_module(
         _surface_reflectance_module,
         surface_reflectance_src,
     ],
-    fortran_args: fortran_args,
+
     install: true,
     dependencies: [fortranobject_dep],
     link_language: 'fortran',
@@ -264,7 +265,7 @@ _satellite_model = py3.extension_module(
         _satellite_model_module,
         satellite_model_src,
     ],
-    fortran_args: fortran_args,
+
     install: true,
     dependencies: [fortranobject_dep],
     link_language: 'fortran',
@@ -300,7 +301,7 @@ _track_time_info = py3.extension_module(
         _track_time_info_module,
         track_time_info_src,
     ],
-    fortran_args: fortran_args,
+
     install: true,
     dependencies: [fortranobject_dep],
     link_language: 'fortran',
@@ -333,7 +334,7 @@ _bilinear_interpolation = py3.extension_module(
         _bilinear_interpolation_module,
         bilinear_interpolation_src,
     ],
-    fortran_args: fortran_args,
+
     install: true,
     dependencies: [fortranobject_dep],
     link_language: 'fortran',


### PR DESCRIPTION
One Fortran module defines its own `pi`, `r2d` etc variables, which conflict with ones in sys_modules.

I initially changed it to use the sys_variables itself, to be consistent with the others, but noticed that it uses slightly different types (real -> double).

To be conservative in our changes, I've instead renamed the local ones to not conflict, and kept them as reals.

(I don't know why the Fortran build recently became stricter in this. Versions of compilers etc seem the same.)

This also fixes some small things found in debugging the problem (that unfortunately didn't fix it)
- Set Fortran args globally, rather than manually. (one module wasn't using our fortran config)
- Use a separate cache for conda vs pip build. This avoids some Docker caching issues.