### PR TITLE
Bump pre-commit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,11 +22,7 @@ repos:
     hooks:
     -   id: ruff
         args: [--fix, --show-fixes, --output-format, grouped]
--   repo: https://github.com/psf/black
-    rev: 23.10.1
-    hooks:
-    -   id: black
-        language_version: python3
+    -   id: ruff-format
 -   repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.6
     # TODO: clean up these old scripts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,14 +11,14 @@ repos:
     -   id: check-toml
     -   id: check-added-large-files
 -   repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.11.0
+    rev: v2.12.0
     hooks:
     -   id: pretty-format-toml
         args: [--autofix, --indent, '4']
     -   id: pretty-format-yaml
         args: [--autofix, --indent, '4']
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3
+    rev: v0.2.1
     hooks:
     -   id: ruff
         args: [--fix, --show-fixes, --output-format, grouped]

--- a/eugl/gqa/tasks.py
+++ b/eugl/gqa/tasks.py
@@ -50,9 +50,7 @@ from wagl.logs import TASK_LOGGER
 from wagl.singlefile_workflow import DataStandardisation
 
 _LOG = logging.getLogger(__name__)
-write_yaml = partial(
-    yaml.safe_dump, default_flow_style=False, indent=4
-)  # pylint: disable=invalid-name
+write_yaml = partial(yaml.safe_dump, default_flow_style=False, indent=4)  # pylint: disable=invalid-name
 
 
 class GverifyTask(luigi.Task):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ ignore = [
     "S101",  # Allow asserts
     "EXE001"  # "Shebang is present, but not executable". Too many to list right now.
 ]
-line-length = 120
 # Which checkers to enable?
 select = [
     "A",  # Don't shadow built-ins
@@ -146,6 +145,11 @@ target-version = "py38"
     "NPY002"  # randint usage. TODO: fixable
 ]
 "wagl/vincenty.py" = ["N802", "N803", "N806", "N816", "N817"]
+
+# Matching old behaviour: We auto-format with the smaller line default
+# ...  but only enforce line length to be under this larger 120 limit.
+[tool.ruff.pycodestyle]
+max-line-length = 120
 
 [tool.setuptools_scm]
 write_to = "wagl/_version.py"

--- a/tesp/sensitivity.py
+++ b/tesp/sensitivity.py
@@ -41,9 +41,7 @@ class ExperimentList(luigi.WrapperTask):
         for tag, settings in experiments.items():
             # a `tag` is a name given to an experiment
             # the `settings` for an experiment is the set of custom parameter values
-            if (
-                not self.tags or tag in self.tags
-            ):  # pylint: disable=unsupported-membership-test
+            if not self.tags or tag in self.tags:  # pylint: disable=unsupported-membership-test
                 yield Experiment(
                     self.level1_list,
                     self.workdir,
@@ -143,9 +141,7 @@ class MergeImages(luigi.Task):
 
     @property
     def _target_dir(self):
-        return pjoin(
-            self.workdir, self.tag, *self.prefix
-        )  # pylint: disable=not-an-iterable
+        return pjoin(self.workdir, self.tag, *self.prefix)  # pylint: disable=not-an-iterable
 
     @property
     def _target(self):

--- a/wagl/reflectance.py
+++ b/wagl/reflectance.py
@@ -48,17 +48,11 @@ def _calculate_reflectance(
         satellite_solar_angles_fname, "r"
     ) as fid_sat_sol, h5py.File(slope_aspect_fname, "r") as fid_slp_asp, h5py.File(
         relative_slope_fname, "r"
-    ) as fid_rel_slp, h5py.File(
-        incident_angles_fname, "r"
-    ) as fid_inc, h5py.File(
+    ) as fid_rel_slp, h5py.File(incident_angles_fname, "r") as fid_inc, h5py.File(
         exiting_angles_fname, "r"
-    ) as fid_exi, h5py.File(
-        shadow_masks_fname, "r"
-    ) as fid_shadow, h5py.File(
+    ) as fid_exi, h5py.File(shadow_masks_fname, "r") as fid_shadow, h5py.File(
         ancillary_fname, "r"
-    ) as fid_anc, h5py.File(
-        out_fname, "w"
-    ) as fid:
+    ) as fid_anc, h5py.File(out_fname, "w") as fid:
         grp1 = fid_interp[GroupName.INTERP_GROUP.value]
         grp2 = fid_sat_sol[GroupName.SAT_SOL_GROUP.value]
         grp3 = fid_slp_asp[GroupName.SLP_ASP_GROUP.value]


### PR DESCRIPTION
Now that ruff supports black-like formatting, we can remove black.

(the newer version of black had a similar diff to some lines)