### PR TITLE
remove land_sea_raster leftovers from PQ removal

### DIFF
--- a/wagl/multifile_workflow.py
+++ b/wagl/multifile_workflow.py
@@ -938,7 +938,6 @@ class DataStandardisation(luigi.Task):
     SurfaceReflectance and SurfaceTemperature.
     """
 
-    land_sea_path = luigi.Parameter()
     dsm_fname = luigi.Parameter(significant=False)
     buffer_distance = luigi.FloatParameter(default=8000, significant=False)
 

--- a/wagl/singlefile_workflow.py
+++ b/wagl/singlefile_workflow.py
@@ -71,7 +71,6 @@ class DataStandardisation(luigi.Task):
     workflow = luigi.EnumParameter(enum=Workflow, default=Workflow.STANDARD)
     vertices = luigi.TupleParameter(default=(5, 5))
     method = luigi.EnumParameter(enum=Method, default=Method.SHEAR)
-    land_sea_path = luigi.Parameter()
     aerosol = luigi.DictParameter(default={"user": 0.05})
     brdf = luigi.DictParameter()
     ozone_path = luigi.Parameter(significant=False)
@@ -112,7 +111,6 @@ class DataStandardisation(luigi.Task):
                 self.workflow,
                 self.vertices,
                 self.method,
-                self.land_sea_path,
                 self.tle_path,
                 self.aerosol,
                 self.brdf,
@@ -159,7 +157,6 @@ class ARD(luigi.WrapperTask):
                     "method": self.method,
                     "modtran_exe": self.modtran_exe,
                     "outdir": outdir,
-                    "land_sea_path": self.land_sea_path,
                     "aerosol": self.aerosol,
                     "brdf": self.brdf,
                     "ozone_path": self.ozone_path,

--- a/wagl/standardise.py
+++ b/wagl/standardise.py
@@ -56,7 +56,6 @@ def card4l(
     workflow,
     vertices,
     method,
-    landsea,
     tle_path,
     aerosol,
     brdf,
@@ -100,10 +99,6 @@ def card4l(
         An enum from wagl.constants.Method representing the
         interpolation method to use during the interpolation
         of the atmospheric coefficients.
-
-    :param landsea:
-        A string containing the full file pathname to the directory
-        containing the land/sea mask datasets.
 
     :param tle_path:
         A string containing the full file pathname to the directory


### PR DESCRIPTION
Remove parameters that propagated the land/sea raster file location needed by the now removed pixel quality code.