### PR TITLE
Fix broken cast shadow by removing Fortran common block

### DIFF
--- a/wagl/f90_sources/cast_shadow_main.f90
+++ b/wagl/f90_sources/cast_shadow_main.f90
@@ -111,8 +111,6 @@ SUBROUTINE cast_shadow_main( &
     real*4 sun_zen
     real*4 htol
     logical exists
-    real pi_real, r2d_real, d2r_real, eps_real
-    common/base/pi_real,r2d_real,d2r_real,eps_real
 
 !f2py intent(in) dem_data, solar_data, sazi_data
 !f2py intent(in) dresx, dresy, spheroid, alat1, alon1
@@ -125,12 +123,6 @@ SUBROUTINE cast_shadow_main( &
 !f2py intent(hide) :: a, solar, sazi, dem, alat, alon, mask
 !f2py intent(out) ierr
 !f2py intent(out) mask_all
-
-!   set basic constants
-    pi_real=4.0*atan(1.0)
-    r2d_real=180.0/pi_real
-    d2r_real=pi_real/180.0
-    eps_real=1.0e-7
 
 !   set the tolerance for occlusion in metres
 !   (usually >0 and less than 10.0m)

--- a/wagl/f90_sources/terrain_border_margins.f90
+++ b/wagl/f90_sources/terrain_border_margins.f90
@@ -14,9 +14,11 @@ SUBROUTINE set_borderf(set_border,phi_sun, zmax, zmin, sun_zen, hx, hy, &
     real*8 hx, hy
     real sinphc, cosphc, d, d0
     real pi_real, d2r_real
-    common/base/pi_real,d2r_real
     logical set_border
 
+!   set basic constants
+    pi_real=4.0*atan(1.0)
+    d2r_real=pi_real/180.0
 
     set_border=.true.
     ierr=0


### PR DESCRIPTION
Pretty sure Fortran common blocks are broken in this environment somehow. Setting common block variables in one function and reading them from another isn't working.