### PR TITLE
Better error message in GQA

### DIFF
--- a/eugl/gqa/geometric_utils.py
+++ b/eugl/gqa/geometric_utils.py
@@ -4,13 +4,14 @@
 
 import datetime
 import logging
-import subprocess
 import typing
 
 import numpy as np
 import rasterio
 import yaml
 from rasterio.warp import Resampling
+
+from eugl.fmask import run_command
 
 # Post SLC-OFF date
 SLC_OFF = datetime.datetime(2003, 6, 1)
@@ -381,6 +382,7 @@ def reproject(
     source_fname: str,
     reference_fname: str,
     out_fname: str,
+    cwd: str,
     resampling: Resampling = Resampling.bilinear,
 ) -> None:
     """Reproject an image.
@@ -393,6 +395,9 @@ def reproject(
 
     :param out_fname:
         A `string` representing the filepath name of the output image.
+
+    :param cwd:
+        Current working directory to execute `gdalwarp` in.
 
     :param resampling:
         The resampling method to use during image re-projection.
@@ -432,7 +437,7 @@ def reproject(
     ]
 
     _LOG.info("calling gdalwarp:\n%s", cmd)
-    subprocess.check_call(cmd)
+    run_command(cmd, cwd)
 
 
 def _populate_nan_residuals() -> typing.Dict:

--- a/eugl/gqa/tasks.py
+++ b/eugl/gqa/tasks.py
@@ -594,7 +594,7 @@ def build_vrt(reference_images, out_file, work_dir):
                 src_file = image.filename
                 ref_file = common_csr.filename
                 out_file = pjoin(temp_directory, basename(src_file))
-                reproject(src_file, ref_file, out_file)
+                reproject(src_file, ref_file, out_file, temp_directory)
                 yield CSR.from_file(out_file)
 
     reprojected = [abspath(image.filename) for image in reprojected_images()]


### PR DESCRIPTION
Most error messages come from the `run_command` function which captures (allegedly) the `stdout` and `stdin`. This particular invocation called the raw `check_call` function that loses the error message.

Pretty minor impact.