### PR TITLE
Refactor the `card4l` function into smaller pieces

### DIFF
--- a/wagl/standardise.py
+++ b/wagl/standardise.py
@@ -188,8 +188,6 @@ def card4l(
     :param normalized_solar_zenith:
         Solar zenith angle to normalize for (in degrees). Default is 45 degrees.
     """
-    json_fmt = pjoin(POINT_FMT, ALBEDO_FMT, "".join([POINT_ALBEDO_FMT, ".json"]))
-    nvertices = vertices[0] * vertices[1]
 
     container = acquisitions(level1, hint=acq_parser_hint)
 
@@ -197,376 +195,514 @@ def card4l(
     with h5py.File(out_fname, "w", driver=h5_driver) as fid:
         fid.attrs["level1_uri"] = level1
 
-        for grp_name in container.supported_groups:
-            log = STATUS_LOGGER.bind(
-                level1=container.label, granule=granule, granule_group=grp_name
-            )
-
-            # root group for a given granule and resolution group
-            root = fid.create_group(ppjoin(granule, grp_name))
-            acqs = container.get_acquisitions(granule=granule, group=grp_name)
-
-            # include the resolution as a group attribute
-            root.attrs["resolution"] = acqs[0].resolution
-
-            # longitude and latitude
-            log.info("Latitude-Longitude")
-            create_lon_lat_grids(acqs[0], root, compression, filter_opts)
-
-            # satellite and solar angles
-            log.info("Satellite-Solar-Angles")
-            calculate_angles(
-                acqs[0],
-                root[GroupName.LON_LAT_GROUP.value],
-                root,
-                compression,
-                filter_opts,
-                tle_path,
-            )
-
-            if workflow in (Workflow.STANDARD, Workflow.NBAR):
-                # DEM
-                log.info("DEM-retriveal")
-                get_dsm(
-                    acqs[0], dsm_fname, buffer_distance, root, compression, filter_opts
-                )
-
-                # slope & aspect
-                log.info("Slope-Aspect")
-                slope_aspect_arrays(
-                    acqs[0],
-                    root[GroupName.ELEVATION_GROUP.value],
-                    buffer_distance,
-                    root,
-                    compression,
-                    filter_opts,
-                )
-
-                # incident angles
-                log.info("Incident-Angles")
-                incident_angles(
-                    root[GroupName.SAT_SOL_GROUP.value],
-                    root[GroupName.SLP_ASP_GROUP.value],
-                    root,
-                    compression,
-                    filter_opts,
-                )
-
-                # exiting angles
-                log.info("Exiting-Angles")
-                exiting_angles(
-                    root[GroupName.SAT_SOL_GROUP.value],
-                    root[GroupName.SLP_ASP_GROUP.value],
-                    root,
-                    compression,
-                    filter_opts,
-                )
-
-                # relative azimuth slope
-                log.info("Relative-Azimuth-Angles")
-                incident_group_name = GroupName.INCIDENT_GROUP.value
-                exiting_group_name = GroupName.EXITING_GROUP.value
-                relative_azimuth_slope(
-                    root[incident_group_name],
-                    root[exiting_group_name],
-                    root,
-                    compression,
-                    filter_opts,
-                )
-
-                # self shadow
-                log.info("Self-Shadow")
-                self_shadow(
-                    root[incident_group_name],
-                    root[exiting_group_name],
-                    root,
-                    compression,
-                    filter_opts,
-                )
-
-                # cast shadow solar source direction
-                log.info("Cast-Shadow-Solar-Direction")
-                dsm_group_name = GroupName.ELEVATION_GROUP.value
-                calculate_cast_shadow(
-                    acqs[0],
-                    root[dsm_group_name],
-                    root[GroupName.SAT_SOL_GROUP.value],
-                    buffer_distance,
-                    root,
-                    compression,
-                    filter_opts,
-                )
-
-                # cast shadow satellite source direction
-                log.info("Cast-Shadow-Satellite-Direction")
-                calculate_cast_shadow(
-                    acqs[0],
-                    root[dsm_group_name],
-                    root[GroupName.SAT_SOL_GROUP.value],
-                    buffer_distance,
-                    root,
-                    compression,
-                    filter_opts,
-                    False,
-                )
-
-                # combined shadow masks
-                log.info("Combined-Shadow")
-                combine_shadow_masks(
-                    root[GroupName.SHADOW_GROUP.value],
-                    root[GroupName.SHADOW_GROUP.value],
-                    root[GroupName.SHADOW_GROUP.value],
-                    root,
-                    compression,
-                    filter_opts,
-                )
-
-        # nbar and sbt ancillary
-        log = STATUS_LOGGER.bind(
-            level1=container.label, granule=granule, granule_group=None
-        )
-
         # granule root group
-        root = fid[granule]
+        root = fid.create_group(granule)
 
-        # get the highest resolution group containing supported bands
-        acqs, grp_name = container.get_highest_resolution(granule=granule)
-
-        grn_con = container.get_granule(granule=granule, container=True)
-        res_group = root[grp_name]
-
-        log.info("Ancillary-Retrieval")
-        nbar_paths = {
-            "aerosol_dict": aerosol,
-            "water_vapour_dict": water_vapour,
-            "ozone_path": ozone_path,
-            "dem_path": dem_path,
-            "brdf_dict": brdf,
-        }
-        collect_ancillary(
-            grn_con,
-            res_group[GroupName.SAT_SOL_GROUP.value],
-            nbar_paths,
-            ecmwf_path,
-            invariant_fname,
-            vertices,
+        stash_oa_bands(
             root,
+            container,
+            granule,
+            tle_path,
+            workflow,
+            dsm_fname,
+            buffer_distance,
             compression,
             filter_opts,
         )
 
-        # atmospherics
-        log.info("Atmospherics")
-
-        ancillary_group = root[GroupName.ANCILLARY_GROUP.value]
-
-        # satellite/solar angles and lon/lat for a resolution group
-        sat_sol_grp = res_group[GroupName.SAT_SOL_GROUP.value]
-        lon_lat_grp = res_group[GroupName.LON_LAT_GROUP.value]
-
-        # TODO: supported acqs in different groups pointing to different response funcs
-        json_data, _ = format_json(
-            acqs, ancillary_group, sat_sol_grp, lon_lat_grp, workflow, root
+        stash_ancillary(
+            root,
+            container,
+            granule,
+            aerosol,
+            water_vapour,
+            ozone_path,
+            dem_path,
+            brdf,
+            ecmwf_path,
+            invariant_fname,
+            vertices,
+            compression,
+            filter_opts,
         )
 
-        # atmospheric inputs group
-        inputs_grp = root[GroupName.ATMOSPHERIC_INPUTS_GRP.value]
+        stash_atmospherics(
+            root,
+            container,
+            granule,
+            workflow,
+            vertices,
+            modtran_exe,
+            compression,
+            filter_opts,
+        )
 
-        # radiative transfer for each point and albedo
-        for key in json_data:
-            point, albedo = key
+        esun_values = stash_reflectance(
+            root,
+            container,
+            granule,
+            workflow,
+            method,
+            rori,
+            normalized_solar_zenith,
+            compression,
+            filter_opts,
+        )
 
-            log.info("Radiative-Transfer", point=point, albedo=albedo.value)
+        stash_metadata(
+            root,
+            container,
+            granule,
+            workflow,
+            vertices,
+            buffer_distance,
+            esun_values,
+            method,
+            rori,
+            normalized_solar_zenith,
+        )
 
-            with tempfile.TemporaryDirectory() as tmpdir:
-                prepare_modtran(acqs, point, [albedo], tmpdir)
 
-                point_dir = pjoin(tmpdir, POINT_FMT.format(p=point))
-                workdir = pjoin(point_dir, ALBEDO_FMT.format(a=albedo.value))
+def stash_oa_bands(
+    granule_root,
+    container,
+    granule,
+    tle_path,
+    workflow,
+    dsm_fname,
+    buffer_distance,
+    compression,
+    filter_opts,
+):
+    for grp_name in container.supported_groups:
+        log = STATUS_LOGGER.bind(
+            level1=container.label, granule=granule, granule_group=grp_name
+        )
 
-                json_mod_infile = pjoin(
-                    tmpdir, json_fmt.format(p=point, a=albedo.value)
-                )
+        # root group for a given granule and resolution group
+        root = granule_root.create_group(grp_name)
+        acqs = container.get_acquisitions(granule=granule, group=grp_name)
 
-                with open(json_mod_infile, "w") as src:
-                    json_dict = json_data[key]
+        # include the resolution as a group attribute
+        root.attrs["resolution"] = acqs[0].resolution
 
-                    if albedo == Albedos.ALBEDO_TH:
-                        json_dict["MODTRAN"][0]["MODTRANINPUT"]["SPECTRAL"][
-                            "FILTNM"
-                        ] = "{}/{}".format(
-                            workdir,
-                            json_dict["MODTRAN"][0]["MODTRANINPUT"]["SPECTRAL"][
-                                "FILTNM"
-                            ],
-                        )
-                        json_dict["MODTRAN"][1]["MODTRANINPUT"]["SPECTRAL"][
-                            "FILTNM"
-                        ] = "{}/{}".format(
-                            workdir,
-                            json_dict["MODTRAN"][1]["MODTRANINPUT"]["SPECTRAL"][
-                                "FILTNM"
-                            ],
-                        )
+        # longitude and latitude
+        log.info("Latitude-Longitude")
+        create_lon_lat_grids(acqs[0], root, compression, filter_opts)
 
-                    else:
-                        json_dict["MODTRAN"][0]["MODTRANINPUT"]["SPECTRAL"][
-                            "FILTNM"
-                        ] = "{}/{}".format(
-                            workdir,
-                            json_dict["MODTRAN"][0]["MODTRANINPUT"]["SPECTRAL"][
-                                "FILTNM"
-                            ],
-                        )
+        # satellite and solar angles
+        log.info("Satellite-Solar-Angles")
+        calculate_angles(
+            acqs[0],
+            root[GroupName.LON_LAT_GROUP.value],
+            root,
+            compression,
+            filter_opts,
+            tle_path,
+        )
 
-                    json.dump(json_dict, src, cls=JsonEncoder, indent=4)
+        if workflow in (Workflow.STANDARD, Workflow.NBAR):
+            # DEM
+            log.info("DEM-retriveal")
+            get_dsm(acqs[0], dsm_fname, buffer_distance, root, compression, filter_opts)
 
-                run_modtran(
-                    acqs,
-                    inputs_grp,
-                    workflow,
-                    nvertices,
-                    point,
-                    [albedo],
-                    modtran_exe,
-                    tmpdir,
-                    root,
-                    compression,
-                    filter_opts,
-                )
-
-        # atmospheric coefficients
-        log.info("Coefficients")
-        results_group = root[GroupName.ATMOSPHERIC_RESULTS_GRP.value]
-        calculate_coefficients(results_group, root, compression, filter_opts)
-        esun_values = {}
-        # interpolate coefficients
-        for grp_name in container.supported_groups:
-            log = STATUS_LOGGER.bind(
-                level1=container.label, granule=granule, granule_group=grp_name
+            # slope & aspect
+            log.info("Slope-Aspect")
+            slope_aspect_arrays(
+                acqs[0],
+                root[GroupName.ELEVATION_GROUP.value],
+                buffer_distance,
+                root,
+                compression,
+                filter_opts,
             )
-            log.info("Interpolation")
 
-            # acquisitions and available bands for the current group level
-            acqs = container.get_acquisitions(granule=granule, group=grp_name)
-            nbar_acqs = [acq for acq in acqs if acq.band_type == BandType.REFLECTIVE]
-            sbt_acqs = [acq for acq in acqs if acq.band_type == BandType.THERMAL]
+            # incident angles
+            log.info("Incident-Angles")
+            incident_angles(
+                root[GroupName.SAT_SOL_GROUP.value],
+                root[GroupName.SLP_ASP_GROUP.value],
+                root,
+                compression,
+                filter_opts,
+            )
 
-            res_group = root[grp_name]
-            sat_sol_grp = res_group[GroupName.SAT_SOL_GROUP.value]
-            comp_grp = root[GroupName.COEFFICIENTS_GROUP.value]
+            # exiting angles
+            log.info("Exiting-Angles")
+            exiting_angles(
+                root[GroupName.SAT_SOL_GROUP.value],
+                root[GroupName.SLP_ASP_GROUP.value],
+                root,
+                compression,
+                filter_opts,
+            )
 
-            for coefficient in workflow.atmos_coefficients:
-                if coefficient is AtmosphericCoefficients.ESUN:
-                    continue
-                if coefficient in Workflow.NBAR.atmos_coefficients:
-                    band_acqs = nbar_acqs
+            # relative azimuth slope
+            log.info("Relative-Azimuth-Angles")
+            incident_group_name = GroupName.INCIDENT_GROUP.value
+            exiting_group_name = GroupName.EXITING_GROUP.value
+            relative_azimuth_slope(
+                root[incident_group_name],
+                root[exiting_group_name],
+                root,
+                compression,
+                filter_opts,
+            )
+
+            # self shadow
+            log.info("Self-Shadow")
+            self_shadow(
+                root[incident_group_name],
+                root[exiting_group_name],
+                root,
+                compression,
+                filter_opts,
+            )
+
+            # cast shadow solar source direction
+            log.info("Cast-Shadow-Solar-Direction")
+            dsm_group_name = GroupName.ELEVATION_GROUP.value
+            calculate_cast_shadow(
+                acqs[0],
+                root[dsm_group_name],
+                root[GroupName.SAT_SOL_GROUP.value],
+                buffer_distance,
+                root,
+                compression,
+                filter_opts,
+            )
+
+            # cast shadow satellite source direction
+            log.info("Cast-Shadow-Satellite-Direction")
+            calculate_cast_shadow(
+                acqs[0],
+                root[dsm_group_name],
+                root[GroupName.SAT_SOL_GROUP.value],
+                buffer_distance,
+                root,
+                compression,
+                filter_opts,
+                False,
+            )
+
+            # combined shadow masks
+            log.info("Combined-Shadow")
+            combine_shadow_masks(
+                root[GroupName.SHADOW_GROUP.value],
+                root[GroupName.SHADOW_GROUP.value],
+                root[GroupName.SHADOW_GROUP.value],
+                root,
+                compression,
+                filter_opts,
+            )
+
+
+def stash_ancillary(
+    root,
+    container,
+    granule,
+    aerosol,
+    water_vapour,
+    ozone_path,
+    dem_path,
+    brdf,
+    ecmwf_path,
+    invariant_fname,
+    vertices,
+    compression,
+    filter_opts,
+):
+    # nbar and sbt ancillary
+    log = STATUS_LOGGER.bind(
+        level1=container.label, granule=granule, granule_group=None
+    )
+
+    # get the highest resolution group containing supported bands
+    acqs, grp_name = container.get_highest_resolution(granule=granule)
+
+    grn_con = container.get_granule(granule=granule, container=True)
+    res_group = root[grp_name]
+
+    log.info("Ancillary-Retrieval")
+    nbar_paths = {
+        "aerosol_dict": aerosol,
+        "water_vapour_dict": water_vapour,
+        "ozone_path": ozone_path,
+        "dem_path": dem_path,
+        "brdf_dict": brdf,
+    }
+    collect_ancillary(
+        grn_con,
+        res_group[GroupName.SAT_SOL_GROUP.value],
+        nbar_paths,
+        ecmwf_path,
+        invariant_fname,
+        vertices,
+        root,
+        compression,
+        filter_opts,
+    )
+
+
+def stash_atmospherics(
+    root,
+    container,
+    granule,
+    workflow,
+    vertices,
+    modtran_exe,
+    compression,
+    filter_opts,
+):
+    log = STATUS_LOGGER.bind(
+        level1=container.label, granule=granule, granule_group=None
+    )
+
+    # get the highest resolution group containing supported bands
+    acqs, grp_name = container.get_highest_resolution(granule=granule)
+    res_group = root[grp_name]
+
+    # atmospherics
+    log.info("Atmospherics")
+
+    ancillary_group = root[GroupName.ANCILLARY_GROUP.value]
+
+    # satellite/solar angles and lon/lat for a resolution group
+    sat_sol_grp = res_group[GroupName.SAT_SOL_GROUP.value]
+    lon_lat_grp = res_group[GroupName.LON_LAT_GROUP.value]
+
+    # TODO: supported acqs in different groups pointing to different response funcs
+    json_data, _ = format_json(
+        acqs, ancillary_group, sat_sol_grp, lon_lat_grp, workflow, root
+    )
+
+    # atmospheric inputs group
+    inputs_grp = root[GroupName.ATMOSPHERIC_INPUTS_GRP.value]
+
+    json_fmt = pjoin(POINT_FMT, ALBEDO_FMT, "".join([POINT_ALBEDO_FMT, ".json"]))
+    nvertices = vertices[0] * vertices[1]
+
+    # radiative transfer for each point and albedo
+    for key in json_data:
+        point, albedo = key
+
+        log.info("Radiative-Transfer", point=point, albedo=albedo.value)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            prepare_modtran(acqs, point, [albedo], tmpdir)
+
+            point_dir = pjoin(tmpdir, POINT_FMT.format(p=point))
+            workdir = pjoin(point_dir, ALBEDO_FMT.format(a=albedo.value))
+
+            json_mod_infile = pjoin(tmpdir, json_fmt.format(p=point, a=albedo.value))
+
+            with open(json_mod_infile, "w") as src:
+                json_dict = json_data[key]
+
+                if albedo == Albedos.ALBEDO_TH:
+                    json_dict["MODTRAN"][0]["MODTRANINPUT"]["SPECTRAL"][
+                        "FILTNM"
+                    ] = "{}/{}".format(
+                        workdir,
+                        json_dict["MODTRAN"][0]["MODTRANINPUT"]["SPECTRAL"]["FILTNM"],
+                    )
+                    json_dict["MODTRAN"][1]["MODTRANINPUT"]["SPECTRAL"][
+                        "FILTNM"
+                    ] = "{}/{}".format(
+                        workdir,
+                        json_dict["MODTRAN"][1]["MODTRANINPUT"]["SPECTRAL"]["FILTNM"],
+                    )
+
                 else:
-                    band_acqs = sbt_acqs
-
-                for acq in band_acqs:
-                    log.info(
-                        "Interpolate",
-                        band_id=acq.band_id,
-                        coefficient=coefficient.value,
-                    )
-                    interpolate(
-                        acq,
-                        coefficient,
-                        ancillary_group,
-                        sat_sol_grp,
-                        comp_grp,
-                        res_group,
-                        compression,
-                        filter_opts,
-                        method,
+                    json_dict["MODTRAN"][0]["MODTRANINPUT"]["SPECTRAL"][
+                        "FILTNM"
+                    ] = "{}/{}".format(
+                        workdir,
+                        json_dict["MODTRAN"][0]["MODTRANINPUT"]["SPECTRAL"]["FILTNM"],
                     )
 
-            # standardised products
-            band_acqs = []
+                json.dump(json_dict, src, cls=JsonEncoder, indent=4)
 
-            if workflow in (Workflow.STANDARD, Workflow.NBAR):
-                band_acqs.extend(nbar_acqs)
+            run_modtran(
+                acqs,
+                inputs_grp,
+                workflow,
+                nvertices,
+                point,
+                [albedo],
+                modtran_exe,
+                tmpdir,
+                root,
+                compression,
+                filter_opts,
+            )
 
-            if workflow in (Workflow.STANDARD, Workflow.SBT):
-                band_acqs.extend(sbt_acqs)
+
+# this function calculates esun values as a byproduct
+# TODO disentangle esun_value extraction
+# TODO (probably by separating interpolation and reflectance)
+def stash_reflectance(
+    root,
+    container,
+    granule,
+    workflow,
+    method,
+    rori,
+    normalized_solar_zenith,
+    compression,
+    filter_opts,
+):
+    # atmospheric coefficients
+    log = STATUS_LOGGER.bind(
+        level1=container.label, granule=granule, granule_group=None
+    )
+    log.info("Coefficients")
+    ancillary_group = root[GroupName.ANCILLARY_GROUP.value]
+    results_group = root[GroupName.ATMOSPHERIC_RESULTS_GRP.value]
+    calculate_coefficients(results_group, root, compression, filter_opts)
+    esun_values = {}
+
+    # interpolate coefficients
+    for grp_name in container.supported_groups:
+        log = STATUS_LOGGER.bind(
+            level1=container.label, granule=granule, granule_group=grp_name
+        )
+        log.info("Interpolation")
+
+        # acquisitions and available bands for the current group level
+        acqs = container.get_acquisitions(granule=granule, group=grp_name)
+        nbar_acqs = [acq for acq in acqs if acq.band_type == BandType.REFLECTIVE]
+        sbt_acqs = [acq for acq in acqs if acq.band_type == BandType.THERMAL]
+
+        res_group = root[grp_name]
+        sat_sol_grp = res_group[GroupName.SAT_SOL_GROUP.value]
+        comp_grp = root[GroupName.COEFFICIENTS_GROUP.value]
+
+        for coefficient in workflow.atmos_coefficients:
+            if coefficient is AtmosphericCoefficients.ESUN:
+                continue
+            if coefficient in Workflow.NBAR.atmos_coefficients:
+                band_acqs = nbar_acqs
+            else:
+                band_acqs = sbt_acqs
 
             for acq in band_acqs:
-                interp_grp = res_group[GroupName.INTERP_GROUP.value]
+                log.info(
+                    "Interpolate",
+                    band_id=acq.band_id,
+                    coefficient=coefficient.value,
+                )
+                interpolate(
+                    acq,
+                    coefficient,
+                    ancillary_group,
+                    sat_sol_grp,
+                    comp_grp,
+                    res_group,
+                    compression,
+                    filter_opts,
+                    method,
+                )
 
-                if acq.band_type == BandType.THERMAL:
-                    log.info("SBT", band_id=acq.band_id)
-                    surface_brightness_temperature(
-                        acq, interp_grp, res_group, compression, filter_opts
-                    )
-                else:
-                    atmos_coefs = read_h5_table(
-                        comp_grp, DatasetName.NBAR_COEFFICIENTS.value
-                    )
-                    esun_values[acq.band_name] = (
-                        atmos_coefs[atmos_coefs.band_name == acq.band_name][
-                            AtmosphericCoefficients.ESUN.value
-                        ]
-                    ).values[0]
+        # standardised products
+        band_acqs = []
 
-                    slp_asp_grp = res_group[GroupName.SLP_ASP_GROUP.value]
-                    rel_slp_asp = res_group[GroupName.REL_SLP_GROUP.value]
-                    incident_grp = res_group[GroupName.INCIDENT_GROUP.value]
-                    exiting_grp = res_group[GroupName.EXITING_GROUP.value]
-                    shadow_grp = res_group[GroupName.SHADOW_GROUP.value]
+        if workflow in (Workflow.STANDARD, Workflow.NBAR):
+            band_acqs.extend(nbar_acqs)
 
-                    log.info("Surface-Reflectance", band_id=acq.band_id)
-                    calculate_reflectance(
-                        acq,
-                        interp_grp,
-                        sat_sol_grp,
-                        slp_asp_grp,
-                        rel_slp_asp,
-                        incident_grp,
-                        exiting_grp,
-                        shadow_grp,
-                        ancillary_group,
-                        rori,
-                        res_group,
-                        compression,
-                        filter_opts,
-                        normalized_solar_zenith,
-                        esun_values[acq.band_name],
-                    )
+        if workflow in (Workflow.STANDARD, Workflow.SBT):
+            band_acqs.extend(sbt_acqs)
 
-        def get_band_acqs(grp_name):
-            acqs = container.get_acquisitions(granule=granule, group=grp_name)
-            nbar_acqs = [acq for acq in acqs if acq.band_type == BandType.REFLECTIVE]
-            sbt_acqs = [acq for acq in acqs if acq.band_type == BandType.THERMAL]
+        for acq in band_acqs:
+            interp_grp = res_group[GroupName.INTERP_GROUP.value]
 
-            band_acqs = []
-            if workflow in (Workflow.STANDARD, Workflow.NBAR):
-                band_acqs.extend(nbar_acqs)
+            if acq.band_type == BandType.THERMAL:
+                log.info("SBT", band_id=acq.band_id)
+                surface_brightness_temperature(
+                    acq, interp_grp, res_group, compression, filter_opts
+                )
+            else:
+                atmos_coefs = read_h5_table(
+                    comp_grp, DatasetName.NBAR_COEFFICIENTS.value
+                )
+                esun_values[acq.band_name] = (
+                    atmos_coefs[atmos_coefs.band_name == acq.band_name][
+                        AtmosphericCoefficients.ESUN.value
+                    ]
+                ).values[0]
 
-            if workflow in (Workflow.STANDARD, Workflow.SBT):
-                band_acqs.extend(sbt_acqs)
+                slp_asp_grp = res_group[GroupName.SLP_ASP_GROUP.value]
+                rel_slp_asp = res_group[GroupName.REL_SLP_GROUP.value]
+                incident_grp = res_group[GroupName.INCIDENT_GROUP.value]
+                exiting_grp = res_group[GroupName.EXITING_GROUP.value]
+                shadow_grp = res_group[GroupName.SHADOW_GROUP.value]
 
-            return band_acqs
+                log.info("Surface-Reflectance", band_id=acq.band_id)
+                calculate_reflectance(
+                    acq,
+                    interp_grp,
+                    sat_sol_grp,
+                    slp_asp_grp,
+                    rel_slp_asp,
+                    incident_grp,
+                    exiting_grp,
+                    shadow_grp,
+                    ancillary_group,
+                    rori,
+                    res_group,
+                    compression,
+                    filter_opts,
+                    normalized_solar_zenith,
+                    esun_values[acq.band_name],
+                )
 
-        # wagl parameters
-        parameters = {
-            "vertices": list(vertices),
-            "method": method.value,
-            "rori": rori,
-            "buffer_distance": buffer_distance,
-            "normalized_solar_zenith": normalized_solar_zenith,
-            "esun": esun_values,
-        }
+    return esun_values
 
-        # metadata yaml's
-        metadata = root.create_group(DatasetName.METADATA.value)
-        create_ard_yaml(
-            {
-                grp_name: get_band_acqs(grp_name)
-                for grp_name in container.supported_groups
-            },
-            ancillary_group,
-            metadata,
-            parameters,
-            workflow,
-        )
+
+def stash_metadata(
+    root,
+    container,
+    granule,
+    workflow,
+    vertices,
+    buffer_distance,
+    esun_values,
+    method,
+    rori,
+    normalized_solar_zenith,
+):
+    def get_band_acqs(grp_name):
+        acqs = container.get_acquisitions(granule=granule, group=grp_name)
+        nbar_acqs = [acq for acq in acqs if acq.band_type == BandType.REFLECTIVE]
+        sbt_acqs = [acq for acq in acqs if acq.band_type == BandType.THERMAL]
+
+        band_acqs = []
+        if workflow in (Workflow.STANDARD, Workflow.NBAR):
+            band_acqs.extend(nbar_acqs)
+
+        if workflow in (Workflow.STANDARD, Workflow.SBT):
+            band_acqs.extend(sbt_acqs)
+
+        return band_acqs
+
+    ancillary_group = root[GroupName.ANCILLARY_GROUP.value]
+
+    # wagl parameters
+    parameters = {
+        "vertices": list(vertices),
+        "method": method.value,
+        "rori": rori,
+        "buffer_distance": buffer_distance,
+        "normalized_solar_zenith": normalized_solar_zenith,
+        "esun": esun_values,
+    }
+
+    # metadata yaml's
+    metadata = root.create_group(DatasetName.METADATA.value)
+    create_ard_yaml(
+        {grp_name: get_band_acqs(grp_name) for grp_name in container.supported_groups},
+        ancillary_group,
+        metadata,
+        parameters,
+        workflow,
+    )


### PR DESCRIPTION
Why?
- `card4l` does "data standardization" as one giant task but I think this breakdown is easier to understand
- it looks like a pipeline now
- let's us profile individual steps more effectively
- let's us track dependencies better
- better still would be to track which HDF5 groups are prerequisites to the tasks
- down the track maybe they can be separate `luigi` tasks, bringing back most of the advantages of `multifile_workflow` but with a level of granularity I am more comfortable with

Changes:
- not much, mostly moving code around
- I think the dependence on the NBAR/SBT bands are clearer now
- the `esun_values` were calculated as a side-effect to interpolating modtran parameters, which is probably not ideal, so refactored it to a separate function
- have separated the interpolation and the reflectance phases

Tests:
- tested on a couple of sample scenes/granules, the refactoring did not introduce any changes
- have learned that for rough areas `terrain_shadow_masks` can be pretty expensive (luckily they are rare)
- for Sentinel-2, modtran and interpolation takes up a much bigger fraction of time compared to Landsat (most probably because more bands)