### PR TITLE
Satellite and solar angle refactor

### DIFF
--- a/wagl/f90_sources/compute_angles.f90
+++ b/wagl/f90_sources/compute_angles.f90
@@ -1,6 +1,8 @@
 ! subroutine cal_angles
 SUBROUTINE cal_angles(lam_p,phip_p,tol_lam,orb_elements,spheroid, &
-             smodel,track,num_tpts,timet,theta_p,azimuth,istat)
+             smodel, track, &
+             sin_orb_incl, cos_orb_incl, tan_orb_incl, &
+             num_tpts,timet,theta_p,azimuth,istat)
 
 !     Cal_Angles is the main routine in the set
 !     It finds the segment of the track model where a line from a point
@@ -51,6 +53,7 @@ SUBROUTINE cal_angles(lam_p,phip_p,tol_lam,orb_elements,spheroid, &
 !           6. hxy
 !           7. mj
 !           8. skew
+!       sin_orb_incl, cos_orb_incl, tan_orb_incl
 !   Outputs
 !       timet
 !       theta_p
@@ -66,6 +69,7 @@ SUBROUTINE cal_angles(lam_p,phip_p,tol_lam,orb_elements,spheroid, &
     double precision, dimension(3), intent(in) :: orb_elements
 !   smodel(phi0,phi0_p,rho0,t0,lam0,gamm0,beta0,rotn0,hxy0,N0,H0,th_ratio0)
     double precision, dimension(12), intent(in) :: smodel
+    double precision, intent(in) :: sin_orb_incl, cos_orb_incl, tan_orb_incl
 
     integer, intent(in) :: num_tpts
 !   track(t,rho,phi_p,lam,beta,hxy,mj,skew)
@@ -117,7 +121,8 @@ SUBROUTINE cal_angles(lam_p,phip_p,tol_lam,orb_elements,spheroid, &
     azimuth = 0.0
 
     temp = phip_p
-    call q_cal(temp,orb_elements,spheroid,smodel,rho_p,t_p,lamcal, &
+    call q_cal(temp,orb_elements,spheroid,smodel, &
+           sin_orb_incl, cos_orb_incl, tan_orb_incl, rho_p,t_p,lamcal, &
            betacal,istat)
 
 !   find where the azimuth of the track crossing at the same phi_p is
@@ -206,7 +211,8 @@ SUBROUTINE cal_angles(lam_p,phip_p,tol_lam,orb_elements,spheroid, &
     phip_test = phi_pt+mjt*(lam_test-lamt)
 
 !   get info at the solution
-    call q_cal(phip_test,orb_elements,spheroid,smodel,rho_c,t_c, &
+    call q_cal(phip_test,orb_elements,spheroid,smodel, &
+           sin_orb_incl, cos_orb_incl, tan_orb_incl, rho_c,t_c, &
            lamt,betacal,istat)
 
 !   calculate the return results

--- a/wagl/f90_sources/geod2geo.f90
+++ b/wagl/f90_sources/geod2geo.f90
@@ -29,7 +29,7 @@ SUBROUTINE geod2geo(yin,orb_elements,spheroid,phip,istat)
     double precision orb_elements(3), spheroid(4)
     double precision orad
     double precision asph, e2
-    double precision rn, temp
+    double precision rn, temp, sin_yin, cos_yin
     integer istat
 
 !   Satellite orbital paramaters
@@ -46,8 +46,10 @@ SUBROUTINE geod2geo(yin,orb_elements,spheroid,phip,istat)
     istat = 0
 
     temp = dble(yin)*d2r
-    RN = asph/sqrt(1.0d0-e2*sin(temp)**2)
-    phip = temp-asin(RN*e2*sin(temp)*cos(temp)/orad)
+    sin_yin = sin(temp)
+    cos_yin = cos(temp)
+    RN = asph/sqrt(1.0d0-e2*sin_yin**2)
+    phip = temp-asin(RN*e2*sin_yin*cos_yin/orad)
 
     return
 

--- a/wagl/f90_sources/q_cal.f90
+++ b/wagl/f90_sources/q_cal.f90
@@ -1,5 +1,6 @@
 ! subroutine q_cal
-SUBROUTINE q_cal(phip,orb_elements,spheroid,smodel,rhocal,tcal, &
+SUBROUTINE q_cal(phip,orb_elements,spheroid,smodel, &
+             sin_orb_incl, cos_orb_incl, tan_orb_incl, rhocal,tcal, &
              lamcal,betacal,istat)
 
 !   base subroutine to calculate base track information
@@ -31,6 +32,9 @@ SUBROUTINE q_cal(phip,orb_elements,spheroid,smodel,rhocal,tcal, &
 !           10. N0
 !           11. H0
 !           12. th_ratio0
+!       sin_orb_incl
+!       cos_orb_incl
+!       tan_orb_incl
 !
 !   Outputs:
 !       rhocal is angle from apogee (rad)
@@ -46,8 +50,8 @@ SUBROUTINE q_cal(phip,orb_elements,spheroid,smodel,rhocal,tcal, &
     double precision phip
 
     double precision orb_elements(3), spheroid(4)
-    double precision oi, ws
-    double precision we
+    double precision sin_orb_incl, cos_orb_incl, tan_orb_incl
+    double precision ws, we
 
     double precision smodel(12)
     double precision t0, gamm0
@@ -58,7 +62,6 @@ SUBROUTINE q_cal(phip,orb_elements,spheroid,smodel,rhocal,tcal, &
 !   Satellite orbital parameters
 !   orbital inclination (degrees)
 !   angular velocity (rad sec-1)
-    oi = orb_elements(1)*d2r
     ws = orb_elements(3)
 
 !   Spheroid paramaters
@@ -72,11 +75,11 @@ SUBROUTINE q_cal(phip,orb_elements,spheroid,smodel,rhocal,tcal, &
 !   Initialise the return status
     istat = 0
 
-    rhocal = acos(sin(phip)/sin(oi))
+    rhocal = acos(sin(phip)/sin_orb_incl)
     tcal = (rhocal+pi/2.0d0)/ws
     lamcal = gamm0-pi/2.0d0+atan(tan(rhocal)/ &
-      cos(oi))-we*(tcal-t0)
-    betacal = atan(-1.0d0/(tan(oi)*sin(rhocal)))
+      cos_orb_incl)-we*(tcal-t0)
+    betacal = atan(-1.0d0/(tan_orb_incl*sin(rhocal)))
 
     return
 

--- a/wagl/f90_sources/satellite_angles_main.f90
+++ b/wagl/f90_sources/satellite_angles_main.f90
@@ -82,6 +82,7 @@ SUBROUTINE satellite_angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,sphe
     double precision xout, yout
     double precision phip_p, lam_p
     double precision timet, theta_p, azimuth
+    double precision, dimension(ntpoints) :: tan_beta
     double precision orb_incl, sin_orb_incl, cos_orb_incl, tan_orb_incl
     integer i, j, istat_elem
 
@@ -94,6 +95,10 @@ SUBROUTINE satellite_angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,sphe
     sin_orb_incl = sin(orb_incl)
     cos_orb_incl = cos(orb_incl)
     tan_orb_incl = tan(orb_incl)
+
+    do i=1,ntpoints
+        tan_beta(i) = tan(track(i, 5))
+    end do
 
     do i=1,nrow
     do j=1,ncol
@@ -117,7 +122,7 @@ SUBROUTINE satellite_angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,sphe
         istat(i, j) = istat_elem
 
         call cal_angles(lam_p, phip_p, tol_lam, orb_elements, &
-               spheroid, smodel, track, &
+               spheroid, smodel, track, tan_beta, &
                sin_orb_incl, cos_orb_incl, tan_orb_incl, &
                ntpoints, timet, theta_p, &
                azimuth, istat_elem)

--- a/wagl/f90_sources/satellite_angles_main.f90
+++ b/wagl/f90_sources/satellite_angles_main.f90
@@ -82,11 +82,18 @@ SUBROUTINE satellite_angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,sphe
     double precision xout, yout
     double precision phip_p, lam_p
     double precision timet, theta_p, azimuth
+    double precision orb_incl, sin_orb_incl, cos_orb_incl, tan_orb_incl
     integer i, j, istat_elem
 
 !f2py depend(nrow, ncol), alat, alon, view, azi, tim
 !f2py depend(nlines), X_cent, N_cent
 !f2py depend(ntpoints), track
+
+!   Orbital inclination
+    orb_incl = orb_elements(1)*d2r
+    sin_orb_incl = sin(orb_incl)
+    cos_orb_incl = cos(orb_incl)
+    tan_orb_incl = tan(orb_incl)
 
     do i=1,nrow
     do j=1,ncol
@@ -110,7 +117,9 @@ SUBROUTINE satellite_angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,sphe
         istat(i, j) = istat_elem
 
         call cal_angles(lam_p, phip_p, tol_lam, orb_elements, &
-               spheroid, smodel, track, ntpoints, timet, theta_p, &
+               spheroid, smodel, track, &
+               sin_orb_incl, cos_orb_incl, tan_orb_incl, &
+               ntpoints, timet, theta_p, &
                azimuth, istat_elem)
 
         if (istat(i, j) .eq. 0) istat(i, j) = istat_elem

--- a/wagl/f90_sources/satellite_angles_main.f90
+++ b/wagl/f90_sources/satellite_angles_main.f90
@@ -1,7 +1,7 @@
 ! subroutine angle
-SUBROUTINE angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,spheroid,orb_elements, &
-             hours,century,ntpoints,smodel,track, &
-             view,azi,asol,soazi,rela_angle,tim,X_cent,N_cent,istat)
+SUBROUTINE satellite_angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,spheroid,orb_elements, &
+             ntpoints,smodel,track, &
+             view,azi,tim,X_cent,N_cent,istat)
 
 !   program to calculate solar, view and azimuth angle from
 !   both UTM and lat/lon projection if we only know one point in the
@@ -27,8 +27,6 @@ SUBROUTINE angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,spheroid,orb_e
 !           1. Orbital inclination (degrees)
 !           2. Semi_major radius (m)
 !           3. Angular velocity (rad sec-1)
-!       hours
-!       century
 !       ntpoints (number of time points created in determining the satellite track)
 !       smodel
 !           1. phi0
@@ -54,9 +52,6 @@ SUBROUTINE angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,spheroid,orb_e
 !           8. skew
 !       view
 !       azi
-!       asol
-!       soazi
-!       rela_angle
 !       tim
 !       X_cent
 !       N_cent
@@ -64,9 +59,6 @@ SUBROUTINE angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,spheroid,orb_e
 !   Outputs
 !       view
 !       azi
-!       asol
-!       soazi
-!       rela_angle
 !       tim
 !       X_cent
 !       N_cent
@@ -80,11 +72,10 @@ SUBROUTINE angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,spheroid,orb_e
     double precision, dimension(nrow, ncol), intent(in) :: alat, alon
     double precision, dimension(4), intent(in) :: spheroid
     double precision, dimension(3), intent(in) :: orb_elements
-    double precision, intent(in) :: hours, century
     integer, intent(in) :: ntpoints
     double precision, dimension(12), intent(in) :: smodel
     double precision, dimension(ntpoints,8), intent(in) :: track
-    real, dimension(nrow, ncol), intent(inout) :: view, azi, asol, soazi, rela_angle, tim
+    real, dimension(nrow, ncol), intent(inout) :: view, azi, tim
     real, dimension(nlines), intent(inout) :: X_cent, N_cent
     integer, dimension(nrow, ncol), intent(out) :: istat
     double precision delxx, tol_lam
@@ -93,7 +84,7 @@ SUBROUTINE angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,spheroid,orb_e
     double precision timet, theta_p, azimuth
     integer i, j, istat_elem
 
-!f2py depend(nrow, ncol), alat, alon, view, azi, asol, soazi, rela_angle, tim
+!f2py depend(nrow, ncol), alat, alon, view, azi, tim
 !f2py depend(nlines), X_cent, N_cent
 !f2py depend(ntpoints), track
 
@@ -111,10 +102,6 @@ SUBROUTINE angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,spheroid,orb_e
 
         tol_lam = delxx*d2r*1.2
 
-!       calculate solar angle
-        call solar(yout*d2r, xout*d2r, century, hours, asol(i, j), &
-               soazi(i, j))
-
 !       go through the base sequence used in the test examples
         lam_p = xout*d2r
 
@@ -130,7 +117,6 @@ SUBROUTINE angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,spheroid,orb_e
         tim(i, j) = timet
         view(i, j) = theta_p*r2d
         azi(i, j) = azimuth*r2d
-        rela_angle(i, j) = azi(i, j)-soazi(i, j)
         if ((abs(timet) .gt. 1.0e-5) .and. (abs(view(i, j)) .lt. 1.0e-7) &
           .and. (abs(azi(i, j)) .lt. 1.0e-7)) then
             X_cent(row_offset + i) = X_cent(row_offset + i)+real(j + col_offset)
@@ -141,4 +127,4 @@ SUBROUTINE angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,spheroid,orb_e
 
     return
 
-END SUBROUTINE angle
+END SUBROUTINE satellite_angle

--- a/wagl/f90_sources/satellite_angles_main.f90
+++ b/wagl/f90_sources/satellite_angles_main.f90
@@ -105,14 +105,15 @@ SUBROUTINE satellite_angle(nrow,ncol,nlines,row_offset,col_offset,alat,alon,sphe
 !       go through the base sequence used in the test examples
         lam_p = xout*d2r
 
-        istat_elem = 0
         call geod2geo(yout, orb_elements, spheroid, phip_p, istat_elem)
+
+        istat(i, j) = istat_elem
 
         call cal_angles(lam_p, phip_p, tol_lam, orb_elements, &
                spheroid, smodel, track, ntpoints, timet, theta_p, &
                azimuth, istat_elem)
 
-        istat(i, j) = istat_elem
+        if (istat(i, j) .eq. 0) istat(i, j) = istat_elem
 
         tim(i, j) = timet
         view(i, j) = theta_p*r2d

--- a/wagl/f90_sources/solar_angle.f90
+++ b/wagl/f90_sources/solar_angle.f90
@@ -1,6 +1,5 @@
 ! subroutine solar
-!subroutine solar(alat,along,iyear,imonth,iday,tt,solar_zen,sazi)
-SUBROUTINE solar(alat,along,century,tt,solar_zen,sazi)
+SUBROUTINE solar(alat,along,tt,sun_declin,eq_time,solar_zen,sazi)
 !   program used to calculate solar angle using NOAA method
 !   it is more accurate and using julian day
 !   the program is written by Fuqin Li in 2010
@@ -10,8 +9,9 @@ SUBROUTINE solar(alat,along,century,tt,solar_zen,sazi)
 !   Inputs:
 !       alat
 !       along
-!       century
 !       tt
+!       sun_declin
+!       eq_time
 
 !   Outputs:
 !       solar_zen
@@ -22,51 +22,17 @@ SUBROUTINE solar(alat,along,century,tt,solar_zen,sazi)
     implicit none
 
     double precision, intent(in) :: alat, along
-    double precision, intent(in) :: century, tt
+    double precision, intent(in) :: tt
+    double precision, intent(in) :: sun_declin
+    double precision, intent(in) :: eq_time
     real, intent(out) :: solar_zen, sazi
-    double precision geom_ss
-    double precision sun_long, sun_anom, eccent, sun_eqc
-    double precision sun_truelong, sun_trueanom
-    double precision sun_rad, sun_app, ecliptic_mean
-    double precision obliq_corr, sun_asc, sun_declin
-    double precision vary, eq_time, suntime_true, hangle
+
+    double precision suntime_true, hangle
     double precision solar_zen1, solar_ele1, atmo
     double precision solar_ele, sss, ss_time
-
-    geom_ss = 280.46646d0+century*(36000.76983d0+century*0.0003032d0)
-    sun_long = dmod(geom_ss,360d0)
-    sun_anom = 357.52911d0+century*(35999.05029d0-0.0001537d0*century)
-    eccent = 0.016708634d0-century*(0.000042037d0+0.0001537d0*century)
-
-    sun_eqc = sin(sun_anom*d2r)*(1.914602d0-century*(0.004817d0+ &
-      0.000014d0*century))+sin(2*sun_anom*d2r)*(0.019993d0-0.000101d0* &
-      century)+sin(3*sun_anom*d2r)*0.000289d0
-
-    sun_truelong = sun_long+sun_eqc
-    sun_trueanom = sun_anom+sun_eqc
-
-    sun_rad = (1.000001018d0*(1-eccent**2))/(1+eccent* &
-      cos(sun_trueanom*d2r))
-
-    sun_app = sun_truelong-0.00569d0-0.00478d0*sin(d2r*(125.04- &
-      1937.136d0*century))
-
-    ecliptic_mean = 23.0+(26.0+((21.448-century*(46.815+century* &
-      (0.00059d0-century*0.001813d0))))/60.0)/60.0
-
-    obliq_corr = ecliptic_mean+0.00256*cos((125.04-1934.136*century)* &
-      d2r)
-
-    sun_asc = r2d*(atan2(cos(sun_app*d2r),cos(obliq_corr*d2r)* &
-      sin(sun_app*d2r)))
-
-    sun_declin = r2d*(asin(sin(obliq_corr*d2r)*sin(sun_app*d2r)))
-    vary = tan(obliq_corr/2.0*d2r)**2
-
-    eq_time = 4*r2d*(vary*sin(2.0*sun_long*d2r)-2*eccent*sin(d2r* &
-      sun_anom)+ 4*eccent*vary*sin(d2r*sun_anom)*cos(2*d2r*sun_long) &
-      -0.5*vary**2* sin(4*d2r*sun_long)-1.25*eccent**2*sin(2*d2r* &
-      sun_anom))
+    double precision sin_alat, cos_alat
+    double precision sin_sun_declin, cos_sun_declin
+    double precision tan_solar_ele1
 
     ss_time = tt*60+eq_time+4*along*r2d
     suntime_true = dmod(ss_time,1440d0)
@@ -77,16 +43,24 @@ SUBROUTINE solar(alat,along,century,tt,solar_zen,sazi)
         hangle = suntime_true/4.0+180
     endif
 
-    solar_zen1 = r2d*(acos(sin(alat)*sin(d2r*sun_declin)+ &
-      cos(alat)*cos(d2r*sun_declin)*cos(d2r*hangle)))
+    sin_alat = sin(alat)
+    cos_alat = cos(alat)
+
+    sin_sun_declin = sin(sun_declin)
+    cos_sun_declin = cos(sun_declin)
+
+    solar_zen1 = r2d*(acos(sin_alat*sin_sun_declin+ &
+      cos_alat*cos_sun_declin*cos(d2r*hangle)))
 
     solar_ele1 = 90.0-solar_zen1
 
     if (solar_ele1 .gt. 85) atmo = 0
 
-    if (solar_ele1 .gt. 5 .and. solar_ele1 .le.85) atmo = 58.1/tan( &
-      solar_ele1*d2r)-0.07/(tan(solar_ele1*d2r)**3)+0.000086d0/ &
-      (tan(solar_ele1*d2r)**5)
+    if (solar_ele1 .gt. 5 .and. solar_ele1 .le.85) then
+      tan_solar_ele1 = tan(solar_ele1*d2r)
+      atmo = 58.1/tan_solar_ele1-0.07/(tan_solar_ele1**3)+0.000086d0/ &
+      (tan_solar_ele1**5)
+    end if
 
     if (solar_ele1 .gt. -0.575 .and. solar_ele1 .le.5) atmo = &
       1735.0+solar_ele1*(-518.2+solar_ele1*(103.4+solar_ele1*(-12.79+ &
@@ -99,11 +73,11 @@ SUBROUTINE solar(alat,along,century,tt,solar_zen,sazi)
     solar_zen = 90-solar_ele
 
     if (hangle .gt. 0) then
-        sss = r2d*(acos(((sin(alat)*cos(d2r*solar_zen1))-sin(d2r* &
-          sun_declin))/(cos(alat)*sin(d2r*solar_zen1))))+180.0
+        sss = r2d*(acos(((sin_alat*cos(d2r*solar_zen1))-sin_sun_declin) &
+            /(cos_alat*sin(d2r*solar_zen1))))+180.0
     else
-        sss = 540.0-r2d*(acos(((sin(alat)*cos(d2r*solar_zen1))- &
-          sin(d2r*sun_declin))/(cos(alat)*sin(d2r*solar_zen1))))
+        sss = 540.0-r2d*(acos(((sin_alat*cos(d2r*solar_zen1))- &
+          sin_sun_declin)/(cos_alat*sin(d2r*solar_zen1))))
     endif
 
     sazi = dmod(sss,360d0)

--- a/wagl/f90_sources/solar_angles_main.f90
+++ b/wagl/f90_sources/solar_angles_main.f90
@@ -31,7 +31,7 @@ SUBROUTINE solar_angle(nrow,ncol,alat,alon, &
     integer, intent(in) :: nrow, ncol
     double precision, dimension(nrow, ncol), intent(in) :: alat, alon
     double precision, intent(in) :: hours, century
-    real, dimension(nrow, ncol), intent(inout) :: asol, soazi 
+    real, dimension(nrow, ncol), intent(inout) :: asol, soazi
     double precision xout, yout
     double precision phip_p, lam_p
     double precision timet, theta_p, azimuth

--- a/wagl/f90_sources/solar_angles_main.f90
+++ b/wagl/f90_sources/solar_angles_main.f90
@@ -32,32 +32,63 @@ SUBROUTINE solar_angle(nrow,ncol,alat,alon, &
     double precision, dimension(nrow, ncol), intent(in) :: alat, alon
     double precision, intent(in) :: hours, century
     real, dimension(nrow, ncol), intent(inout) :: asol, soazi 
-    double precision delxx, tol_lam
     double precision xout, yout
     double precision phip_p, lam_p
     double precision timet, theta_p, azimuth
+    double precision geom_ss, sun_long, sun_anom, eccent, sun_eqc
+    double precision sun_truelong, sun_trueanom
+    double precision sun_rad, sun_app, ecliptic_mean
+    double precision obliq_corr, sun_asc, sun_declin
+    double precision vary, eq_time
     integer i, j
 
 !f2py depend(nrow, ncol), alat, alon, asol, soazi
 !f2py depend(ntpoints), track
+
+    geom_ss = 280.46646d0+century*(36000.76983d0+century*0.0003032d0)
+    sun_long = dmod(geom_ss,360d0)
+    sun_anom = 357.52911d0+century*(35999.05029d0-0.0001537d0*century)
+    eccent = 0.016708634d0-century*(0.000042037d0+0.0001537d0*century)
+
+    sun_eqc = sin(sun_anom*d2r)*(1.914602d0-century*(0.004817d0+ &
+      0.000014d0*century))+sin(2*sun_anom*d2r)*(0.019993d0-0.000101d0* &
+      century)+sin(3*sun_anom*d2r)*0.000289d0
+
+    sun_truelong = sun_long+sun_eqc
+    sun_trueanom = sun_anom+sun_eqc
+
+    sun_rad = (1.000001018d0*(1-eccent**2))/(1+eccent* &
+      cos(sun_trueanom*d2r))
+
+    sun_app = sun_truelong-0.00569d0-0.00478d0*sin(d2r*(125.04- &
+      1937.136d0*century))
+
+    ecliptic_mean = 23.0+(26.0+((21.448-century*(46.815+century* &
+      (0.00059d0-century*0.001813d0))))/60.0)/60.0
+
+    obliq_corr = ecliptic_mean+0.00256*cos((125.04-1934.136*century)* &
+      d2r)
+
+    sun_asc = r2d*(atan2(cos(sun_app*d2r),cos(obliq_corr*d2r)* &
+      sin(sun_app*d2r)))
+
+    sun_declin = r2d*(asin(sin(obliq_corr*d2r)*sin(sun_app*d2r)))
+    vary = tan(obliq_corr/2.0*d2r)**2
+
+    eq_time = 4*r2d*(vary*sin(2.0*sun_long*d2r)-2*eccent*sin(d2r* &
+      sun_anom)+ 4*eccent*vary*sin(d2r*sun_anom)*cos(2*d2r*sun_long) &
+      -0.5*vary**2* sin(4*d2r*sun_long)-1.25*eccent**2*sin(2*d2r* &
+      sun_anom))
 
     do i=1,nrow
     do j=1,ncol
         xout = alon(i, j)
         yout = alat(i, j)
 
-!       calculate pixel size (half)
-        if (j .gt. 1) then
-            delxx = (alon(i, j)-alon(i, j-1))/2
-        else
-            delxx = (alon(i, j+1)-alon(i, j))/2
-        endif
-
-        tol_lam = delxx*d2r*1.2
-
 !       calculate solar angle
-        call solar(yout*d2r, xout*d2r, century, hours, asol(i, j), &
-               soazi(i, j))
+        call solar(yout*d2r, xout*d2r, hours, &
+               sun_declin*d2r, eq_time, &
+               asol(i, j), soazi(i, j))
     enddo
     enddo
 

--- a/wagl/f90_sources/solar_angles_main.f90
+++ b/wagl/f90_sources/solar_angles_main.f90
@@ -1,0 +1,66 @@
+! subroutine angle
+SUBROUTINE solar_angle(nrow,ncol,alat,alon, &
+             hours,century, &
+             asol,soazi)
+
+!   program to calculate solar, view and azimuth angle from
+!   both UTM and lat/lon projection if we only know one point in the
+!   satellite track. the program is written by Fuqin Li, Mar., 2014.
+!   the subroutines cal_angle are from David Jupp
+
+!   * Re-written as an F2Py subroutine by JS, Aug 2014
+
+!   Inputs:
+!       nrow
+!       ncol
+!       alat
+!       alon
+!       hours
+!       century
+!       asol
+!       soazi
+!
+!   Outputs
+!       asol
+!       soazi
+
+    use sys_variables, only : pi, d2r, r2d
+
+    implicit none
+
+    integer, intent(in) :: nrow, ncol
+    double precision, dimension(nrow, ncol), intent(in) :: alat, alon
+    double precision, intent(in) :: hours, century
+    real, dimension(nrow, ncol), intent(inout) :: asol, soazi 
+    double precision delxx, tol_lam
+    double precision xout, yout
+    double precision phip_p, lam_p
+    double precision timet, theta_p, azimuth
+    integer i, j
+
+!f2py depend(nrow, ncol), alat, alon, asol, soazi
+!f2py depend(ntpoints), track
+
+    do i=1,nrow
+    do j=1,ncol
+        xout = alon(i, j)
+        yout = alat(i, j)
+
+!       calculate pixel size (half)
+        if (j .gt. 1) then
+            delxx = (alon(i, j)-alon(i, j-1))/2
+        else
+            delxx = (alon(i, j+1)-alon(i, j))/2
+        endif
+
+        tol_lam = delxx*d2r*1.2
+
+!       calculate solar angle
+        call solar(yout*d2r, xout*d2r, century, hours, asol(i, j), &
+               soazi(i, j))
+    enddo
+    enddo
+
+    return
+
+END SUBROUTINE solar_angle

--- a/wagl/f90_sources/track_time_info.f90
+++ b/wagl/f90_sources/track_time_info.f90
@@ -67,19 +67,28 @@ SUBROUTINE set_times(ymin,ymax,ntpoints,spheroid,orb_elements, &
     double precision, dimension(12), intent(in) :: smodel
     double precision t_min, t_max, phip_max, phip_min, rhocal, tcal
     double precision lamcal, betacal, delta_t
+    double precision orb_incl, sin_orb_incl, cos_orb_incl, tan_orb_incl
     integer j
     integer istat   ! not used, so not going to be pedantic about usage
 
     istat = 0
 
+!   Orbital inclination
+    orb_incl = orb_elements(1)*d2r
+    sin_orb_incl = sin(orb_incl)
+    cos_orb_incl = cos(orb_incl)
+    tan_orb_incl = tan(orb_incl)
+
 !   set up the time range to use for the satellite track
     call geod2geo(ymax,orb_elements,spheroid,phip_max,istat)
-    call q_cal(phip_max,orb_elements,spheroid,smodel,rhocal,tcal, &
+    call q_cal(phip_max,orb_elements,spheroid,smodel, &
+                  sin_orb_incl, cos_orb_incl, tan_orb_incl, rhocal,tcal, &
                   lamcal,betacal,istat)
     t_min = tcal-5.0d0
 
     call geod2geo(ymin,orb_elements,spheroid,phip_min,istat)
-    call q_cal(phip_min,orb_elements,spheroid,smodel,rhocal,tcal, &
+    call q_cal(phip_min,orb_elements,spheroid,smodel, &
+                  sin_orb_incl, cos_orb_incl, tan_orb_incl, rhocal,tcal, &
                   lamcal,betacal,istat)
     t_max = tcal+5.0d0
 

--- a/wagl/f90_sources/track_time_info.f90
+++ b/wagl/f90_sources/track_time_info.f90
@@ -1,6 +1,6 @@
 ! subroutine set_times
 SUBROUTINE set_times(ymin,ymax,ntpoints,spheroid,orb_elements, &
-             smodel,psx,psy,track,istat)
+             smodel,psx,psy,track)
 
 !   Calculate satellite track times and other info
 
@@ -48,7 +48,6 @@ SUBROUTINE set_times(ymin,ymax,ntpoints,spheroid,orb_elements, &
 !
 !   Outputs:
 !       track
-!       istat
 
     use sys_variables, only : pi, d2r, r2d
 
@@ -56,7 +55,6 @@ SUBROUTINE set_times(ymin,ymax,ntpoints,spheroid,orb_elements, &
 
     double precision, intent(in) :: ymin, ymax
     integer, intent(in) :: ntpoints
-    integer, intent(out) :: istat
 
     double precision, dimension(4), intent(in) :: spheroid
     double precision, dimension(3), intent(in) :: orb_elements
@@ -70,6 +68,7 @@ SUBROUTINE set_times(ymin,ymax,ntpoints,spheroid,orb_elements, &
     double precision t_min, t_max, phip_max, phip_min, rhocal, tcal
     double precision lamcal, betacal, delta_t
     integer j
+    integer istat   ! not used, so not going to be pedantic about usage
 
     istat = 0
 

--- a/wagl/meson.build
+++ b/wagl/meson.build
@@ -46,7 +46,8 @@ sat_sol_angles_src = [
     'f90_sources/geod2geo.f90',
     'f90_sources/q_cal.f90',
     'f90_sources/compute_angles.f90',
-    'f90_sources/satellite_solar_angles_main.f90',
+    'f90_sources/satellite_angles_main.f90',
+    'f90_sources/solar_angles_main.f90',
 ]
 _sat_sol_angles_module = custom_target(
     'sat_sol_angles_module',

--- a/wagl/satellite_solar_angles.py
+++ b/wagl/satellite_solar_angles.py
@@ -6,8 +6,8 @@ import ephem
 import numpy as np
 from osgeo import osr
 
-from wagl.__sat_sol_angles import solar_angle as solar_angle_prim
 from wagl.__sat_sol_angles import satellite_angle as satellite_angle_prim
+from wagl.__sat_sol_angles import solar_angle as solar_angle_prim
 from wagl.__satellite_model import set_satmod
 from wagl.__track_time_info import set_times
 from wagl.constants import DatasetName, GroupName, TrackIntersection
@@ -818,26 +818,8 @@ def _store_parameter_settings(
     attach_table_attributes(track_dset, title="Satellite Track", attrs=attrs)
 
 
-def solar_angle(
-    nrow,
-    ncol,
-    alat,
-    alon,
-    hours,
-    century,
-    asol,
-    soazi
-):
-    solar_angle_prim(
-        nrow,
-        ncol,
-        alat,
-        alon,
-        hours,
-        century,
-        asol,
-        soazi
-    )
+def solar_angle(nrow, ncol, alat, alon, hours, century, asol, soazi):
+    solar_angle_prim(nrow, ncol, alat, alon, hours, century, asol, soazi)
 
 
 def satellite_angle(
@@ -856,8 +838,8 @@ def satellite_angle(
     view,
     azi,
     tim,
-    X_cent,
-    N_cent
+    x_cent,
+    n_cent,
 ):
     stat = satellite_angle_prim(
         nrow,
@@ -875,15 +857,12 @@ def satellite_angle(
         view,
         azi,
         tim,
-        X_cent,
-        N_cent
+        x_cent,
+        n_cent,
     )
 
     if np.any(stat != 0):
-        msg = (
-            "Error in calculating angles, "
-            "No interval found in track!"
-        )
+        msg = "Error in calculating angles, no interval found in track!"
         raise RuntimeError(msg)
 
 

--- a/wagl/satellite_solar_angles.py
+++ b/wagl/satellite_solar_angles.py
@@ -752,7 +752,7 @@ def setup_times(ymin, ymax, spheroid, orbital_elements, smodel, psx, psy, ntpoin
                        ('lam', 'f8'), ('beta', 'f8'), ('hxy', 'f8'),
                        ('mj', 'f8'), ('skew', 'f8')]
     """
-    track, _ = set_times(
+    track = set_times(
         ymin, ymax, ntpoints, spheroid, orbital_elements, smodel, psx, psy
     )
 

--- a/wagl/satellite_solar_angles.py
+++ b/wagl/satellite_solar_angles.py
@@ -859,7 +859,7 @@ def satellite_angle(
     X_cent,
     N_cent
 ):
-    return satellite_angle_prim(
+    stat = satellite_angle_prim(
         nrow,
         ncol,
         nlines,
@@ -878,6 +878,13 @@ def satellite_angle(
         X_cent,
         N_cent
     )
+
+    if np.any(stat != 0):
+        msg = (
+            "Error in calculating angles, "
+            "No interval found in track!"
+        )
+        raise RuntimeError(msg)
 
 
 def calculate_angles(
@@ -1146,7 +1153,7 @@ def calculate_angles(
             soazi,
         )
 
-        stat = satellite_angle(
+        satellite_angle(
             dims[0],
             dims[1],
             acquisition.lines,
@@ -1165,13 +1172,6 @@ def calculate_angles(
             x_cent,
             n_cent,
         )
-
-        if np.any(stat != 0):
-            msg = (
-                "Error in calculating angles, "
-                "No interval found in track!"
-            )
-            raise RuntimeError(msg)
 
         # output to disk
         sat_v_ds[idx] = view


### PR DESCRIPTION
This rather large refactor still produces _identical_ results.

Why?
- so that I have to wait a _little_ less time to reproduce an issue
- time is money 💰

How?
- move time related calculations (same for all pixels) to the top-level function for solar angles
- pre-calculate orbital inclination trig functions (sin, cos, tan) and pass it to the pixel-level function
- when a trig function is repeated in an expression, pre-compute it (probably a bit overkill)

Before:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.771    0.771  961.791  961.791 wagl/standardise.py:273(stash_oa_bands)
        4  394.802   98.700  423.416  105.854 wagl/terrain_shadow_masks.py:245(calculate_cast_shadow)
        2  293.811  146.905  332.816  166.408 wagl/satellite_solar_angles.py:820(calculate_angles)
83296/83292    2.927    0.000   66.404    0.001 h5py/_hl/dataset.py:749(__getitem__)
        2   34.454   17.227   49.246   24.623 wagl/incident_exiting_angles.py:16(incident_angles)
        2   30.507   15.254   45.273   22.636 wagl/incident_exiting_angles.py:157(exiting_angles)
        2    0.118    0.059   41.155   20.577 wagl/longitude_latitude_arrays.py:96(create_lon_lat_grids)
    63674   33.528    0.001   39.089    0.001 h5py/_hl/dataset.py:858(__setitem__)
        4    0.000    0.000   28.889    7.222 wagl/interpolation.py:141(interpolate_grid)
  87380/4    0.298    0.000   28.888    7.222 wagl/interpolation.py:185(__interpolate_grid_inner)
    65536    4.300    0.000   28.509    0.000 wagl/interpolation.py:102(interpolate_block)
        2    0.066    0.033   25.456   12.728 wagl/dsm.py:44(get_dsm)
        2   17.147    8.574   23.309   11.655 wagl/slope_aspect.py:15(slope_aspect_arrays)
       54    0.006    0.000   21.164    0.392 h5py/_hl/group.py:67(create_dataset)
```
After:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.800    0.800  881.163  881.163 wagl/standardise.py:273(stash_oa_bands)
        4  384.242   96.060  411.173  102.793 wagl/terrain_shadow_masks.py:245(calculate_cast_shadow)
        2    0.548    0.274  243.270  121.635 wagl/satellite_solar_angles.py:869(calculate_angles)
     4898  160.010    0.033  160.128    0.033 wagl/satellite_solar_angles.py:825(satellite_angle)
83296/83292    5.864    0.000   89.541    0.001 h5py/_hl/dataset.py:749(__getitem__)
        2   32.195   16.097   60.140   30.070 wagl/incident_exiting_angles.py:157(exiting_angles)
        2   34.464   17.232   47.753   23.876 wagl/incident_exiting_angles.py:16(incident_angles)
    63674   35.029    0.001   45.722    0.001 h5py/_hl/dataset.py:858(__setitem__)
     4898   44.653    0.009   44.653    0.009 wagl/satellite_solar_angles.py:821(solar_angle)
        2    4.398    2.199   28.132   14.066 wagl/incident_exiting_angles.py:302(relative_azimuth_slope)
        2    0.071    0.035   27.356   13.678 wagl/dsm.py:44(get_dsm)
        2   17.134    8.567   23.359   11.680 wagl/slope_aspect.py:15(slope_aspect_arrays)
        2    0.113    0.056   21.966   10.983 wagl/longitude_latitude_arrays.py:72(create_lon_lat_grids)
       54    0.013    0.000   20.568    0.381 h5py/_hl/group.py:67(create_dataset)
```
The functions that get a performance boost in this PR are `calculate_angles` (and the PR before was for `create_lon_lat_grids`).

I would not read too much into it because NCI can be flaky. But this is a PoC that there are opportunities here.

@jeremyh I would like to investigate if and how we can utilize vector instructions.