### PR TITLE
Avoid loading whole images into memory in cast shadow

### DIFF
--- a/deployment/dataset-cmp
+++ b/deployment/dataset-cmp
@@ -34,6 +34,16 @@ def find_yaml_file(path: Path) -> List[Path]:
     return fs
 
 
+def show(result):
+    if result is None or result["diff"] == 0:
+        secho("identical", fg="green")
+    else:
+        secho(
+            f'\t{result["diff"]} pixels differ ({result["same"]} same), max difference {result["max_diff"]}',
+            fg="red",
+        )
+
+
 def compare(original_pkg: Path, new_package: Path):
     failures = 0
     original_yamls = find_yaml_file(original_pkg)
@@ -84,10 +94,7 @@ def compare(original_pkg: Path, new_package: Path):
             result = compare_images(new_image_path, old_image_path)
 
             if result["diff"] > 0:
-                secho(
-                    f'\t{result["diff"]} pixels differ ({result["same"]} same), max difference {result["max_diff"]}',
-                    fg="red",
-                )
+                show(result)
                 failures += 1
 
     if failures:
@@ -147,16 +154,6 @@ def display_difference(difference, i, j, chunk_size):
         f"Difference between the two images (chunk from {i},{j} to {i + chunk_size[0]},{j + chunk_size[1]})"
     )
     plt.show()
-
-
-def show(result):
-    if result is None:
-        secho("identical", fg="green")
-    else:
-        secho(
-            f"not identical! max diff: {result['max_diff']}, same: {result['same']}, diff: {result['diff']}",
-            fg="red",
-        )
 
 
 @click.command(help=__doc__)


### PR DESCRIPTION
This refactor does not change any outputs.

Why?
- Cast shadow calculations are not "local" (pixel-by-pixel), so they need to load surrounding pixels too
- Because of the 15m panchromatic band in Landsat imagery this means about 7GB of in memory data
- But both on AWS and NCI, the standard memory/CPU is about 4GB, which means we essentially pay twice the compute cost
- Strangely, the underlying code was carefully written to operate on smaller slices but somehow something got lost in translation

Changes:
- Emulate the outer `for` loop in the Fortran file `cast_shadow_main.f90` in our Python code
- [in Fortran `for` is called `do` because why not]
- This lets us read only a horizontal slab and pass it onto `cast_shadow_main.f90` which correctly handles it
- [so the outer `do` loop there is now useless but 🤷🏽‍♂️]
- Why not do it for the inner loop as well? Because for unknown reasons the `zmax` and `zmin` values are calculated per horizontal slab and not per inner blocks
- Remove the Fortran code for non-UTM calculations that were not implemented fully anyway
- This simplifies the Fortran function interface somewhat and lets us avoid useless spheroidal calculations (but that had little performance impact anyway)
- Now the maximum resident memory is about 2GB!

Of course, we have to roll it out to AWS to actually save some money.