### PR TITLE
Fix conda activation

### DIFF
--- a/deployment/nci/create-module.sh
+++ b/deployment/nci/create-module.sh
@@ -81,10 +81,12 @@ export conda_root="${package_dest}/conda"
 "${this_dir}/../create-conda-environment.sh" "${conda_root}"
 
 set +u
+
+# We cannot use `activate`, as it tries to use the caller's script parameters ("$@"), causing spurious failures.
 # dynamic, so shellcheck can't check it.
 # shellcheck source=/dev/null
-. "${conda_root}/bin/activate"
-# conda activate ard
+source "${conda_root}/etc/profile.d/conda.sh"
+conda activate base
 
 # this seems to be killing conda?
 # set -u


### PR DESCRIPTION
The `activate` script isn't written in a way that is safe to call from within another script. It leaks arguments from the outer script — so certain arguments (in our case, the name of our module) leak through to conda's own logic.

(I have no idea why it would use the `$@` variable if it's only designed to be sourced — that's what's causing the trouble)