### PR TITLE
provide scipy.interpolate as an alternative

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -199,7 +199,7 @@ If you're a user that would like to intersect any part of the dependency tree, t
    band_name =
 
    # The interpolation method to use;
-   # *BILINEAR*, *SHEAR*, or *SHEARB*
+   # *SCIPY*, *BILINEAR*, *SHEAR*, or *SHEARB*
    # internally defaults to SHEAR
    method = SHEAR
 
@@ -214,7 +214,7 @@ If you're a user that would like to intersect any part of the dependency tree, t
    compression = lzf
 
    # The interpolation method to use;
-   # *BILINEAR*, *SHEAR*, or *SHEARB*
+   # *SCIPY*, *BILINEAR*, *SHEAR*, or *SHEARB*
    method = SHEAR
 
    [DEMExctraction]
@@ -302,7 +302,7 @@ If you're a user that would like to intersect any part of the dependency tree, t
    pixel_quality = false
 
    # The interpolation method to use;
-   # *BILINEAR*, *SHEAR*, or *SHEARB*
+   # *SCIPY*, *BILINEAR*, *SHEAR*, or *SHEARB*
    method = SHEAR
 
    [ARD]
@@ -317,5 +317,5 @@ If you're a user that would like to intersect any part of the dependency tree, t
    pixel_quality = false
 
    # The interpolation method to use;
-   # *BILINEAR*, *SHEAR*, or *SHEARB*
+   # *SCIPY*, *BILINEAR*, *SHEAR*, or *SHEARB*
    method = SHEAR

--- a/wagl/constants.py
+++ b/wagl/constants.py
@@ -194,6 +194,7 @@ class Method(Enum):
     BILINEAR = 0
     SHEAR = 2
     SHEARB = 3
+    SCIPY = 4
 
 
 class BrdfModelParameters(Enum):


### PR DESCRIPTION
No changes in behavior. But added the capability to interpolate using the `scipy.interpolate` module.

The result is not identical but the difference in the atmospheric coefficients is <1%. It speeds up interpolation by a little (about ~10-20%).

The key finding is that we actually do not need to support/maintain the sheared bilinear interpolation method if we don't want to.