### PR TITLE
Fix batch_summary command

### DIFF
--- a/tesp/scripts/ard_pbs.py
+++ b/tesp/scripts/ard_pbs.py
@@ -46,7 +46,7 @@ SUMMARY_TEMPLATE = """{pbs_resources}
 #PBS -W depend=afterany:{jobids}
 
 source {env}
-batch_summary --indir {indir} --outdir {outdir}
+ard_batch_summary --indir {indir} --outdir {outdir}
 
 # jq queries
 # concatenate logs to enable querying on a single file


### PR DESCRIPTION
This command was packaged as "ard_batch_summary" to avoid clashes in the unified repository, but ard_pbs jobs were still being generated with the old command. Fix it.