### PR TITLE
Fix recent issues

### DIFF
--- a/wagl/acquisition/__init__.py
+++ b/wagl/acquisition/__init__.py
@@ -733,8 +733,8 @@ def acquisitions_via_safe(pathname: str) -> AcquisitionsContainer:
                 attrs["solar_irradiance"] = solar_irradiance[band_id]
                 attrs["d2"] = 1 / u
                 attrs["qv"] = qv
-                if band_id in offsets:
-                    attrs["offset"] = offsets[band_id]
+            if band_id in offsets:
+                attrs["offset"] = offsets[band_id]
 
             # Required attribute for packaging
             attrs["granule_xml"] = granule_xml

--- a/wagl/brdf.py
+++ b/wagl/brdf.py
@@ -835,6 +835,10 @@ def get_brdf_data(
         tally = get_tally2(mode, dt)
         fallback_brdf = True if mode == "fallback" else False
 
+    # purely ocean datasets are ok for the offshore territories
+    if offshore and all(tally[ds].is_empty() for ds in tally):
+        fallback_brdf = False
+
     spatial_averages = {}
     for ds in tally:
         spatial_averages[ds] = tally[ds].mean()

--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -46,7 +46,7 @@ def get_dsm(
     acquisition,
     srtm_pathname,
     cop_pathname,
-    buffer_distance=12000,
+    buffer_distance=15000,
     out_group=None,
     compression=H5CompressionFilter.LZF,
     filter_opts=None,
@@ -71,7 +71,7 @@ def get_dsm(
         A number representing the desired distance (in the same
         units as the acquisition) in which to calculate the extra
         number of pixels required to buffer an image.
-        Default is 8000.
+        Default is 15000.
 
     :param out_group:
         A writeable HDF5 `Group` object.

--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -46,7 +46,7 @@ def get_dsm(
     acquisition,
     srtm_pathname,
     cop_pathname,
-    buffer_distance=8000,
+    buffer_distance=12000,
     out_group=None,
     compression=H5CompressionFilter.LZF,
     filter_opts=None,

--- a/wagl/f90_sources/cast_shadow_main.f90
+++ b/wagl/f90_sources/cast_shadow_main.f90
@@ -67,7 +67,7 @@ SUBROUTINE cast_shadow_main( &
 !   ierr = 74: 'matrix A does not have sufficient x buffer'
 
     integer*4 k_setting
-    parameter (k_setting=1500)
+    parameter (k_setting=2000)
 
 ! arguments
     real*4 dem_data(nl, ns) !

--- a/wagl/margins.py
+++ b/wagl/margins.py
@@ -41,11 +41,11 @@ class ImageMargins:
         return msg
 
 
-def pixel_buffer(acquisition, distance=8000):
+def pixel_buffer(acquisition, distance=15000):
     """Determine a buffer in pixel units given an `Acquisition` and
     distance.
     If the acquistion's pixel units are in metres, then a distance
-    of 8000 would equate to 8000 metres.
+    of 15000 would equate to 15000 metres.
     The result of the number of pixels to buffer is rounded up to
     the next whole integer.
     For determining the approproate distance to use as a buffer
@@ -61,7 +61,7 @@ def pixel_buffer(acquisition, distance=8000):
         A number representing the desired distance (in the same
         units as the acquisition) in which to calculate the extra
         number of pixels required to buffer an image.
-        Default is 8000.
+        Default is 15000.
 
     :return:
         An instance of an `ImageMargins` object with each of:

--- a/wagl/singlefile_workflow.py
+++ b/wagl/singlefile_workflow.py
@@ -89,7 +89,7 @@ class DataStandardisation(luigi.Task):
     )
     filter_opts = luigi.DictParameter(default=None, significant=False)
     acq_parser_hint = luigi.OptionalParameter(default="")
-    buffer_distance = luigi.FloatParameter(default=8000, significant=False)
+    buffer_distance = luigi.FloatParameter(default=15000, significant=False)
     h5_driver = luigi.OptionalParameter(default="", significant=False)
     normalized_solar_zenith = luigi.FloatParameter(default=45.0)
 

--- a/wagl/slope_aspect.py
+++ b/wagl/slope_aspect.py
@@ -69,7 +69,6 @@ def slope_aspect_arrays(
         A number representing the desired distance (in the same
         units as the acquisition) in which to calculate the extra
         number of pixels required to buffer an image.
-        Default is 8000.
 
     :param out_group:
         A writeable HDF5 `Group` object.

--- a/wagl/terrain_shadow_masks.py
+++ b/wagl/terrain_shadow_masks.py
@@ -354,7 +354,6 @@ def calculate_cast_shadow(
         A number representing the desired distance (in the same
         units as the acquisition) in which to calculate the extra
         number of pixels required to buffer an image.
-        Default is 8000.
 
     :param out_group:
         A writeable HDF5 `Group` object.


### PR DESCRIPTION
- Fix `s2cloudless` band offset issue (offset was not being applied to B9, B10 because we don't produce ARD for them)
- Fix datasets being stuck in `interim` maturity when there is no available BRDF (ocean tiles)
- Fix Heard Island cast shadow issue (shadow calculations needs more buffer)