### PR TITLE
add perl to the NRT docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN --mount=type=cache,target=/var/cache/dnf,id=dnfprod <<EOF
         findutils \
         jq \
         xmlstarlet \
+        perl \
         unzip \
         which
 EOF


### PR DESCRIPTION
but the NRT processing needs `perl` to do some argument processing.