### PR TITLE
README docs fix for setuptools_scm 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # ARD Pipeline
-------
 
 A Python package for producing standarised imagery in the form of:
 
@@ -13,14 +12,14 @@ The luigi task workflow for producing NBAR for a Landsat 5TM scene is given belo
 ![](docs/source/diagrams/luigi-task-visualiser-reduced.png)
 
 ## Supported Satellites and Sensors
------------------------------------
+
 * Landsat 5 TM
 * Landsat 7 ETM
 * Landsat 8+9 OLI+TIRS
 * Sentinel 2a+b
 
 ## Development
----------------
+
 
 A [Justfile](https://github.com/casey/just) is included in the repo for running common commands.
 
@@ -124,6 +123,7 @@ $ pip install "setuptools_scm[toml]>=6.2,<8"
 ``` 
 
 ### Additional HDF5 compression filters (optional)
+
 Additional compression filters can be used via HDF5's
 [dynamically loaded filters](https://support.hdfgroup.org/HDF5/doc/Advanced/DynamicallyLoadedFilters/HDF5DynamicallyLoadedFilters.pdf).
 Essentially the filter needs to be compiled against the HDF5 library, and
@@ -133,11 +133,13 @@ accessible by HDF5 via the [integer code](https://support.hdfgroup.org/services/
 assigned to the filter.
 
 #### Mafisc compression filter
+
 Mafisc combines both a bitshuffling filter and lzma compression filter in order
 to get the best compression possible at the cost of lower compression speeds.
 To install the `mafisc` compression filter, follow these [instructions](https://wr.informatik.uni-hamburg.de/research/projects/icomex/mafisc).
 
 #### Bitshuffle
+
 The [bitshuffle filter](https://github.com/kiyo-masui/bitshuffle) can be installed
 from source, or conda via the supplied [conda recipe](https://github.com/kiyo-masui/bitshuffle/tree/master/conda-recipe).
 It utilises a bitshuffling filter on top of either a lz4 or lzf compression filter.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A script is provided to build Conda with dependencies:
 
     # Activate the environment in the current shell
     . ~/conda/bin/activate
-    
+
     # Ensure build dependencies are installed
     pip install "setuptools_scm[toml]>=6.2,<8"
 
@@ -95,7 +95,7 @@ Run checks locally using the `./check-code.sh` file.
 The `./check-code.sh` script can fail like:
 
 ```Bash
-$ ./deployment/check-environment.sh 
+$ ./deployment/check-environment.sh
 Checking environment...
 Trying rasterio... ✅ 1.3.9
 Trying luigi... ✅ 3.5.0
@@ -108,10 +108,10 @@ Attempting load of fortran-based modules... Traceback (most recent call last):
 ModuleNotFoundError: No module named 'wagl._version'
 ```
 
-This indicates the `setuptools_scm` dependency is too _new_. Check the installed version with:  
+This indicates the `setuptools_scm` dependency is too _new_. Check the installed version with:
 
 ```Bash
-$ pip freeze | grep setuptools_scm 
+$ pip freeze | grep setuptools_scm
 ```
 
 If installed, this will display output like `setuptools-scm==8.1.0`.
@@ -120,7 +120,7 @@ The current workaround is to check the desired version of `setuptools-scm` from 
 
 ```Bash
 $ pip install "setuptools_scm[toml]>=6.2,<8"
-``` 
+```
 
 ### Additional HDF5 compression filters (optional)
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A script is provided to build Conda with dependencies:
     . ~/conda/bin/activate
 
     # Ensure build dependencies are installed
-    pip install "setuptools_scm[toml]>=6.2,<8"
+    python3 -m setuptools_scm  # prints version string if OK
 
     # Install ARD for development
     pip install --no-build-isolation --editable .

--- a/README.md
+++ b/README.md
@@ -49,12 +49,15 @@ native dependencies.
 
 A script is provided to build Conda with dependencies:
 
-```
+```Bash
     # Create environment in ~/conda directory
     ./deployment/create-conda-environment.sh ~/conda
 
     # Activate the environment in the current shell
     . ~/conda/bin/activate
+    
+    # Ensure build dependencies are installed
+    pip install "setuptools_scm[toml]>=6.2,<8"
 
     # Install ARD for development
     pip install --no-build-isolation --editable .
@@ -79,7 +82,7 @@ in the repo.
 You can avoid this, and still maintain live editing, by
 doing a non-isolated editable install:
 
-```
+```Bash
     python3 -m pip install --no-build-isolation --editable .
 ```
 
@@ -87,6 +90,38 @@ Meson will then auto-build the native modules as needed and
 you can run directly from your source directory.
 
 Run checks locally using the `./check-code.sh` file.
+
+**setuptools_scm dependency**
+
+The `./check-code.sh` script can fail like:
+
+```Bash
+$ ./deployment/check-environment.sh 
+Checking environment...
+Trying rasterio... ✅ 1.3.9
+Trying luigi... ✅ 3.5.0
+Trying wagl... x
+        No module named 'wagl._version'
+Attempting load of fortran-based modules... Traceback (most recent call last):
+  File "<stdin>", line 29, in <module>
+  File "/g/data/u46/users/bpd578/projects/ard-pipeline/wagl/__init__.py", line 5, in <module>
+    from ._version import __version__
+ModuleNotFoundError: No module named 'wagl._version'
+```
+
+This indicates the `setuptools_scm` dependency is too _new_. Check the installed version with:  
+
+```Bash
+$ pip freeze | grep setuptools_scm 
+```
+
+If installed, this will display output like `setuptools-scm==8.1.0`.
+
+The current workaround is to check the desired version of `setuptools-scm` from the `pyproject.toml` configuration. If the installed version is higher than the `pyproject.toml` version, uninstall the new version & install an older version, e.g.:
+
+```Bash
+$ pip install "setuptools_scm[toml]>=6.2,<8"
+``` 
 
 ### Additional HDF5 compression filters (optional)
 Additional compression filters can be used via HDF5's

--- a/deployment/environment.yaml
+++ b/deployment/environment.yaml
@@ -210,6 +210,7 @@ dependencies:
 -   scikit-learn=1.3.0
 -   scipy=1.11.4
 -   setuptools=68.2.2
+-   setuptools_scm>=6.2,<8
 -   six=1.16.0
 -   snappy=1.1.10
 -   snuggs=1.4.7


### PR DESCRIPTION
Resolves #55.

This PR adds some docs & troubleshooting help to ensure the right `setuptools_scm` dependency is installed, thus preventing downstream build problems.

Additional: some markdown tidying.