### PR TITLE
update GitHub artifact actions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,7 +17,7 @@ jobs:
         -   run: git describe --tags > git-tag.txt
 
         -   name: Upload tag as artifact
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4
             with:
                 name: ard-pipeline-tag
                 path: git-tag.txt
@@ -38,7 +38,7 @@ jobs:
             run: docker save ard-pipeline:dev > ard-pipeline-image.tar
 
         -   name: Upload image as artifact
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4
             with:
                 name: ard-pipeline-image
                 path: ard-pipeline-image.tar
@@ -58,13 +58,13 @@ jobs:
         steps:
         -   uses: docker/setup-buildx-action@v2
 
-        -   uses: actions/download-artifact@v2
+        -   uses: actions/download-artifact@v4
             with:
                 name: ard-pipeline-tag
 
         -   run: cat git-tag.txt
 
-        -   uses: actions/download-artifact@v2
+        -   uses: actions/download-artifact@v4
             with:
                 name: ard-pipeline-image
 


### PR DESCRIPTION
Because of https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/, they are throwing errors.