### PR TITLE
Docstring/typo fixes

### DIFF
--- a/wagl/ancillary.py
+++ b/wagl/ancillary.py
@@ -252,7 +252,7 @@ def collect_ancillary(
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -355,7 +355,7 @@ def collect_sbt_ancillary(
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -607,6 +607,9 @@ def collect_nbar_ancillary(
         A `str` containing the full file pathname to the directory
         containing the digital elevation model data.
 
+    :param cop_pathname:
+        TODO.
+
     :param brdf_dict:
         A `dict` defined as either of the following:
 
@@ -738,16 +741,19 @@ def get_aerosol_data(
 def get_elevation_data(lonlat: LonLat, pathname: PathWithDataset, offshore: bool):
     """Get elevation data for a scene.
 
-    :param lon_lat:
+    :param lonlat:
         The latitude, longitude of the scene center.
-    :type lon_lat:
+    :type lonlat:
         float (2-tuple)
 
-    :pathname:
+    :param pathname:
         The pathname of the DEM with a ':' to separate the
         dataset name.
-    :type dem_dir:
+    :type pathname:
         str
+
+    :param offshore:
+        TODO.
     """
 
     try:

--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -61,7 +61,7 @@ def get_dsm(
         An instance of an acquisition object.
 
     :param srtm_pathname:
-        A string pathname of the SRTM DSM with a ':' to seperate the
+        A string pathname of the SRTM DSM with a ':' to separate the
         filename from the import HDF5 dataset name.
 
     :param cop_pathname:
@@ -84,7 +84,7 @@ def get_dsm(
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*

--- a/wagl/hdf5/__init__.py
+++ b/wagl/hdf5/__init__.py
@@ -130,15 +130,18 @@ def create_image_dataset(
     :param shape:
         The shape/dimensions of the dataset to create.
 
+    :param dtype:
+        TODO.
+
     :param compression:
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :attrs:
+    :param attrs:
         A `dict` by which the keys will be the attribute name, and the
         values will be the attribute value.
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -190,7 +193,7 @@ def write_h5_image(
         A `dict` of key, value items to be attached as attributes
         to the `Table` dataset.
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -256,7 +259,7 @@ def write_h5_table(
         A `dict` of key, value items to be attached as attributes
         to the `Table` dataset.
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -305,7 +308,7 @@ def write_dataframe(
         A `dict` of key, value items to be attached as attributes
         to the `Table` dataset.
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*

--- a/wagl/hdf5/compression.py
+++ b/wagl/hdf5/compression.py
@@ -12,12 +12,12 @@ https://support.hdfgroup.org/HDF5/doc/Advanced/DynamicallyLoadedFilters/HDF5Dyna
 for more details.
 
 The class implementation utilises python-attrs
-https://github.com/python-attrs/attrs for it's simplicity in
+https://github.com/python-attrs/attrs for its simplicity in
 writing classes that can make use of default values after initialisation,
 as well as the validators to help ensure that incorrect user inputs are
 captured prior to dataset creation.
-Also, all sub-classes of H5CompressionConfig are implemented as frozen instances
-(immuteable). This is purely so each instance can act as a configuration,
+Also, all subclasses of H5CompressionConfig are implemented as frozen instances
+(immutable). This is purely so each instance can act as a configuration,
 such that a different setting will be a different configuration.
 See http://www.attrs.org/en/stable/examples.html#immutability for more details.
 """
@@ -42,6 +42,7 @@ class H5CompressionFilter(IntEnum):
         >>>     fid.create_dataset('random-ints', data=data, **kwargs)
     """
 
+    # TODO: duplicates several constants in BloscCompression
     BLOSC_LZ = 0
     BLOSC_LZ4 = 1
     BLOSC_LZ4HC = 2
@@ -84,7 +85,7 @@ class H5CompressionFilter(IntEnum):
 
 
 class BloscCompression(IntEnum):
-    """Comression filter ids for the blosc metafamily of compressors."""
+    """Compression filter ids for the blosc metafamily of compressors."""
 
     BLOSC_LZ = 0
     BLOSC_LZ4 = 1
@@ -109,7 +110,7 @@ class H5CompressionConfig:
     """Base class for defining HDF5 compression filters.
     Users that know what they're doing can customise the
     dataset compression filter configuration here.
-    But mostly, this class acts as a way for sub-classes to
+    But mostly, this class acts as a way for subclasses to
     access the dataset_compression_kwargs method.
     """
 

--- a/wagl/incident_exiting_angles.py
+++ b/wagl/incident_exiting_angles.py
@@ -83,7 +83,7 @@ def incident_angles(
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -220,7 +220,7 @@ def exiting_angles(
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -358,7 +358,7 @@ def relative_azimuth_slope(
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*

--- a/wagl/longitude_latitude_arrays.py
+++ b/wagl/longitude_latitude_arrays.py
@@ -29,9 +29,9 @@ def coord_getters(geobox, geo_crs=None, centre=True):
         to WGS84.
 
     :param centre:
-        A boolean indicating whether or not the returned co-ordinate
-        should reference the centre of a pixel, in which case a 0.5
-        offset is applied in the x & y directions. Default is True.
+        A boolean indicating if the returned co-ordinate should reference
+        the centre of a pixel, in which case a 0.5 offset is applied in
+        the x & y directions. Default is True.
 
     :return:
         A function that returns the longitude and latitudes
@@ -87,20 +87,22 @@ def create_lon_lat_grids(
 
         The dataset names will be given by:
 
-        * contants.DatasetName.LON.value
-        * contants.DatasetName.LAT.value
+        * constants.DatasetName.LON.value
+        * constants.DatasetName.LAT.value
 
     :param compression:
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
-        instance of H5CompressionFilter. For example
-        H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
-        available.
+        instance of H5CompressionFilter. For example H5CompressionFilter.LZF
+        has the keywords *chunks* and *shuffle* available.
         Default is None, which will use the default settings for the
         chosen H5CompressionFilter instance.
+
+    :param depth:
+        TODO.
 
     :return:
         An opened `h5py.File` object, that is either in-memory using the

--- a/wagl/reflectance.py
+++ b/wagl/reflectance.py
@@ -206,7 +206,7 @@ def calculate_reflectance(
         A float value type to normalize reflectance to a particular angle.
 
     :param esun
-        A float value type. A solar solar irradiance normal to atmosphere
+        A float value type. A solar irradiance normal to atmosphere
         in unit of W/sq cm/sr/nm.
 
     :return:

--- a/wagl/satellite_solar_angles.py
+++ b/wagl/satellite_solar_angles.py
@@ -36,6 +36,9 @@ def convert_to_lonlat(geobox, col_index, row_index, centre=True):
     :param row_index:
         A 1D `NumPy` array of integers representing the row indices.
 
+    :param centre:
+        TODO.
+
     :return:
         2x 1D `NumPy` arrays, of type float64, containing the
         (longitude, latitude) coordinates.
@@ -69,8 +72,7 @@ def create_centreline_dataset(geobox, x, n, out_group):
 
     :param n:
         A 1D np array of type int with the same shape as x.
-        Details whether or not the track point coordinate is
-        averaged.
+        Details if the track point coordinate is averaged.
 
     :param out_group:
         A writeable HDF5 `Group` object.
@@ -385,11 +387,11 @@ def create_vertices(acquisition, boxline_dataset, vertices=(3, 3)):
     :param acquisition:
         An instance of an `Acquisition` object.
 
-    :param boxline:
+    :param boxline_dataset:
         The dataset containing the bi-section (satellite track)
         coordinates. The datatype should be the same as that returned
         by the `satellite_solar_angles.create_boxline` function.
-    :type boxline:
+    :type boxline_dataset:
         [('row_index', 'int64'), ('bisection_index', 'int64'),
          ('npoints', 'int64'), ('start_index', 'int64'),
          ('end_index', 'int64')]
@@ -465,7 +467,7 @@ def calculate_julian_century(datetime):
     j2_epoch = ephem.julian_date(epoch)
 
     # Note:
-    # This differes from online sources such as
+    # This differs from online sources such as
     # http://www.pietro.org/astro_util_staticdemo/FDetailDateConversions.htm
     # http://en.wikipedia.org/wiki/Equinox_(celestial_coordinates)
     # which use:
@@ -476,15 +478,15 @@ def calculate_julian_century(datetime):
 
 
 def setup_spheroid(proj_wkt):
-    """Given a WKT projection string, determine the spheroid paramaters
-    that will be used in calcultating the angle grids.
+    """Given a WKT projection string, determine the spheroid parameters
+    that will be used in calculating the angle grids.
 
     :param proj_wkt:
         A string containing valid WKT projection information.
 
     :return:
         A floating point np array of 4 elements containing
-        spheroidal paramaters.
+        spheroidal parameters.
 
             * Index 0 contains the spheroid Major Axis.
             * Index 1 contains the spheroid Inverse Flattening.
@@ -916,7 +918,7 @@ def calculate_angles(
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -926,6 +928,9 @@ def calculate_angles(
 
     :param tle_path:
         A `str` to the directory containing the Two Line Element data.
+
+    :param trackpoints:
+        TODO.
 
     :return:
         An opened `h5py.File` object, that is either in-memory using the

--- a/wagl/scripts/wagl_residuals.py
+++ b/wagl/scripts/wagl_residuals.py
@@ -83,11 +83,10 @@ def image_residual(
         Default is H5CompressionFilter.LZF
 
     :param save_inputs:
-        A `bool` indicating whether or not to save the input datasets
-        used for evaluating the residuals alongside the results.
-        Default is False.
+        A `bool` indicating whether to save the input datasets used for
+        evaluating the residuals alongside the results. Default is False.
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -233,7 +232,7 @@ def scalar_residual(ref_fid, test_fid, pathname, out_fid, save_inputs):
         writing the output data.
 
     :param save_inputs:
-        A `bool` indicating whether or not to save the input datasets
+        A `bool` indicating whether to save the input datasets
         used for evaluating the residuals alongside the results.
         Default is False.
 
@@ -311,11 +310,11 @@ def table_residual(
         Default is H5CompressionFilter.LZF
 
     :param save_inputs:
-        A `bool` indicating whether or not to save the input datasets
+        A `bool` indicating whether to save the input datasets
         used for evaluating the residuals alongside the results.
         Default is False.
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -400,11 +399,11 @@ def residuals(
         Default is H5CompressionFilter.LZF
 
     :param save_inputs:
-        A `bool` indicating whether or not to save the input datasets
+        A `bool` indicating whether to save the input datasets
         used for evaluating the residuals alongside the results.
         Default is False.
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -631,24 +630,24 @@ def _parser():
     parser.add_argument(
         "--test-filename",
         required=True,
-        help=("The filename of the file containing the test " "datasets."),
+        help="Filename containing the test datasets.",
     )
     parser.add_argument(
         "--reference-filename",
         required=True,
-        help=("The filename of the file containing the " "reference datasets."),
+        help="Filename containing the reference datasets.",
     )
     parser.add_argument(
         "--out-filename",
         required=True,
-        help=("The filename of the file to contain the " "results."),
+        help="Filename contain the results.",
     )
     parser.add_argument(
         "--compression",
         default="LZF",
         choices=list(H5CompressionFilter),
         type=lambda compression: H5CompressionFilter[compression],
-        help="The comression filter to use.",
+        help="The compression filter to use.",
     )
     parser.add_argument(
         "--filter-opts",

--- a/wagl/slope_aspect.py
+++ b/wagl/slope_aspect.py
@@ -83,7 +83,7 @@ def slope_aspect_arrays(
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*

--- a/wagl/temperature.py
+++ b/wagl/temperature.py
@@ -60,7 +60,7 @@ def surface_brightness_temperature(
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -78,7 +78,7 @@ def surface_brightness_temperature(
         parse through the H5 Group object, which in most cases
         reduced the number or parameters being parsed through.
         Thereby simplifying the overall workflow, and making it
-        consistant with other functions within the overall workflow.
+        consistent with other functions within the overall workflow.
     """
     acq = acquisition
     geobox = acq.gridded_geo_box()
@@ -221,7 +221,7 @@ def get_landsat_temperature(acquisitions, pq_const):
 
 def temperature_at_sensor(thermal_acquisition, window=None):
     """Given a thermal acquisition, convert to at sensor temperature
-    in Kelivn.
+    in Kelvin.
 
     :param thermal_acquisition:
         An acquisition with a band_type of BandType.Thermal.

--- a/wagl/terrain_shadow_masks.py
+++ b/wagl/terrain_shadow_masks.py
@@ -48,7 +48,7 @@ def self_shadow(
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -138,7 +138,7 @@ class CastShadowError(FortranError):
     @staticmethod
     def get_error_message(code):
         """Generate an error message for a specific code. It is OK for this have
-        non-returning control paths, as this will results in ``None``, which
+        non-returning control paths, as this will result in ``None``, which
         is handled in the super class.
         """
 
@@ -299,8 +299,9 @@ def calculate_cast_shadow(
     filter_opts=None,
     solar_source=True,
 ):
-    """This code is an interface to the fortran code
-    cast_shadow_main.f90 written by Fuqin (and modified to
+    """
+    This code is an interface to the fortran code
+    cast_shadow_main.f90 written by Fuqin Li (and modified to
     work with F2py).
 
     The following was taken from the top of the Fotran program:
@@ -317,15 +318,15 @@ def calculate_cast_shadow(
     little within the sub-matrix A, then the Landsat scene can be
     divided into several sub_matrix.
     For Australian region, with 0 .00025 degree resolution, the
-    sub-marix A is set to 500x500
+    sub-matrix A is set to 500x500
 
     we also need to set extra DEM lines/columns to run the Landsat
     scene. This will change with elevation
     difference within the scene and solar zenith angle. For
     Australian region and Landsat scene with 0.00025 degree
     resolution, the maximum extra lines are set to 250 pixels/lines
-    for each direction. This figure shold be sufficient for everywhere
-    and anytime in Australia. Thus the DEM image will be larger than
+    for each direction. This figure should be sufficient for everywhere
+    and anytime in Australia. Thus, the DEM image will be larger than
     landsat image for 500 lines x 500 columns
 
     :param acquisition:
@@ -364,10 +365,9 @@ def calculate_cast_shadow(
         * DatasetName.CAST_SHADOW_FMT
 
     :param compression:
-        The compression filter to use.
-        Default is H5CompressionFilter.LZF
+        The compression filter to use. Default is H5CompressionFilter.LZF.
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*
@@ -376,9 +376,8 @@ def calculate_cast_shadow(
         chosen H5CompressionFilter instance.
 
     :param solar_source:
-        A `bool` indicating whether or not the source for the line
-        of sight comes from the sun (True; Default), or False
-        indicating the satellite.
+        A `bool` indicating if the source for the line of sight comes
+        from the sun (True; Default), or False indicating the satellite.
 
     :return:
         An opened `h5py.File` object, that is either in-memory using the
@@ -406,7 +405,7 @@ def calculate_cast_shadow(
     azimuth_angle = satellite_solar_group[azimuth_name]
     elevation = dsm_group[DatasetName.DSM_SMOOTHED.value]
 
-    # block height and width of the window/submatrix used in the cast
+    # block height and width of the window/sub-matrix used in the cast
     # shadow algorithm
     block_width = margins.left + margins.right
     block_height = margins.top + margins.bottom
@@ -469,7 +468,7 @@ def combine_shadow_masks(
     compression=H5CompressionFilter.LZF,
     filter_opts=None,
 ):
-    """A convienice function for combining the shadow masks into a single
+    """A convenience function for combining the shadow masks into a single
     boolean array.
 
     :param self_shadow_group:
@@ -485,12 +484,12 @@ def combine_shadow_masks(
 
         * DatasetName.CAST_SHADOW_FMT
 
-    :param cast_shadow_sun_group:
+    :param cast_shadow_satellite_group:
         The root HDF5 `Group` that contains the cast shadow
         (satellite direction) dataset specified by the pathname
         given by:
 
-        * DatasetName.CAST_SHDADOW_FMT
+        * DatasetName.CAST_SHADOW_FMT
 
     :param out_group:
         A writeable HDF5 `Group` object.
@@ -504,7 +503,7 @@ def combine_shadow_masks(
         The compression filter to use.
         Default is H5CompressionFilter.LZF
 
-    :filter_opts:
+    :param filter_opts:
         A dict of key value pairs available to the given configuration
         instance of H5CompressionFilter. For example
         H5CompressionFilter.LZF has the keywords *chunks* and *shuffle*


### PR DESCRIPTION
This is a documentation cleanup PR. Most fixes are docstring formatting for API docs & typos.