### PR TITLE
Fix hdf5 imports in `deployment/check-environment.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ python3 -m setuptools_scm  # prints version string if OK
 pip install --no-build-isolation --editable .
 
 # Check the environment for common problems.
-# (Eg, can we import dependencies?)
+# (Eg, can we import dependencies on NCI?)
+module use /g/data/v10/private/modules/modulefiles  # allow MODTRAN module loading
+module load modtran
 ./deployment/check-environment.sh
 
 # (note that the last check is for Modtran, which you may or may not be using in your environment. On NCI, we can `module load modtran`)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ pip install --no-build-isolation --editable .
 ./deployment/check-environment.sh
 
 # (note that the last check is for Modtran, which you may or may not be using in your environment. On NCI, we can `module load modtran`)
-
+#
+# FAILED runs will print an error, or may display Python code
+#        in the terminal. This may obscure failure output.   
+#
+# SUCCESSFUL runs will display several module imports & HDF5 tests. 
 ```
 
 ### Import errors
@@ -81,7 +85,7 @@ These are due to the native modules (c, fortran) needing built
 in the repo.
 
 You can avoid this, and still maintain live editing, by
-doing a non-isolated editable install:
+doing a non-isolated editable installation:
 
 ```Bash
 python3 -m pip install --no-build-isolation --editable .

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ pip install --no-build-isolation --editable .
 # (note that the last check is for Modtran, which you may or may not be using in your environment. On NCI, we can `module load modtran`)
 #
 # FAILED runs will print an error, or may display Python code
-#        in the terminal. This may obscure failure output.   
+#        in the terminal. This may obscure failure output.
 #
-# SUCCESSFUL runs will display several module imports & HDF5 tests. 
+# SUCCESSFUL runs will display several module imports & HDF5 tests.
 ```
 
 ### Import errors

--- a/deployment/check-environment.sh
+++ b/deployment/check-environment.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# The check environment script is intended as a fast sanity test. This ensures
+# the major components of the environment are installed, can make use of wagl,
+# workflow runners, HDF5 & geospatial libraries.
+#
+# Usage examples:
+# $ check-environment.sh  # no args required
+
 set -eu
 
 echo Checking environment...

--- a/deployment/check-environment.sh
+++ b/deployment/check-environment.sh
@@ -47,12 +47,28 @@ print("Attempting load of fortran-based modules... ", end='', flush=True)
 from wagl import singlefile_workflow
 print("✅")
 
-# The previous import of wagl should have initialised the filters.
+# TODO CHECK: The previous import of wagl should have initialised the filters.
 print("Attempting hdf5 blosc compression...", end='', flush=True)
 import h5py
+import hdf5plugin
 import tempfile
+
+# Test different forms of compression usage as per the hdf5plugin docs:
+# https://hdf5plugin.readthedocs.io/en/stable/usage.html
+# use "hdf5plugin.Blosc()" style instead of int code to prevent crashes
+print("Attempting hdf5 blosc compression...", end='', flush=True)
 f = h5py.File(tempfile.mktemp('-test.h5'),'w')
-dset = f.create_dataset("myData", (100, 100), compression=32001)
+dset = f.create_dataset("myData", (100, 100), compression=hdf5plugin.Blosc())
+print("✅")
+
+print("Attempting alternate/default hdf5 blosc compression...", end='', flush=True)
+from wagl.hdf5 import H5CompressionFilter
+compressor = H5CompressionFilter.BLOSC_LZ
+config = compressor.config(chunks=(100, 100), shuffle=False)
+kwargs = config.dataset_compression_kwargs()
+
+f2 = h5py.File(tempfile.mktemp('-test.h5'),'w')
+dset2 = f2.create_dataset("myData", (100, 100), **kwargs)
 print("✅")
 
 EOF

--- a/deployment/check-environment.sh
+++ b/deployment/check-environment.sh
@@ -57,25 +57,17 @@ print("✅")
 # TODO CHECK: The previous import of wagl should have initialised the filters.
 print("Attempting hdf5 blosc compression...", end='', flush=True)
 import h5py
-import hdf5plugin
 import tempfile
-
-# Test different forms of compression usage as per the hdf5plugin docs:
-# https://hdf5plugin.readthedocs.io/en/stable/usage.html
-# use "hdf5plugin.Blosc()" style instead of int code to prevent crashes
-print("Attempting hdf5 blosc compression...", end='', flush=True)
-f = h5py.File(tempfile.mktemp('-test.h5'),'w')
-dset = f.create_dataset("myData", (100, 100), compression=hdf5plugin.Blosc())
-print("✅")
-
-print("Attempting alternate/default hdf5 blosc compression...", end='', flush=True)
 from wagl.hdf5 import H5CompressionFilter
+
+# use wagl's custom setup for dataset creation options, which provides args
+# to prevent this test from crashing
 compressor = H5CompressionFilter.BLOSC_LZ
-config = compressor.config(chunks=(100, 100), shuffle=False)
+config = compressor.config(shuffle=False)
 kwargs = config.dataset_compression_kwargs()
 
-f2 = h5py.File(tempfile.mktemp('-test.h5'),'w')
-dset2 = f2.create_dataset("myData", (100, 100), **kwargs)
+f = h5py.File(tempfile.mktemp('-test.h5'),'w')
+dset = f.create_dataset("myData", (100, 100), **kwargs)
 print("✅")
 
 EOF


### PR DESCRIPTION
Closes #59.

This PR switches `deployment/check-environment.sh` to use filter objects instead of int codes. This is an attempt to prevent core dump crashes on some platforms that cannot handle int codes as the `compression=...` option.

Also added, a second check in the script to build a hdf5 dataset using default options.

I've also added a TODO to check if importing `wagl` actually initialises the filters. This was failing in some cases.