### PR TITLE
Add usage help to `deployment/nci/create-module.sh`

### DIFF
--- a/deployment/nci/create-module.sh
+++ b/deployment/nci/create-module.sh
@@ -35,12 +35,7 @@ Create environment in a custom dir, with custom version:
 $ module_dir=/g/data/users/person/modules ./deployment/nci/create-module.sh v1.0
 "
 
-if [ "$1" == "-h" ]; then
-  echo "$usage_text"
-  exit 0
-fi
-
-if [ "$1" == "--help" ]; then
+if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
   echo "$usage_text"
   exit 0
 fi

--- a/deployment/nci/create-module.sh
+++ b/deployment/nci/create-module.sh
@@ -35,7 +35,11 @@ Create environment in a custom dir, with custom version:
 $ module_dir=/g/data/users/person/modules ./deployment/nci/create-module.sh v1.0
 "
 
-if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+# users can provide the version number as the first argument, otherwise make a date-based one
+version="${1:-$(date '+%Y%m%d-%H%M')}"
+
+# is 1st arg (the version) a help flag?
+if [ "$version" == "-h" ] || [ "$version" == "--help" ]; then
   echo "$usage_text"
   exit 0
 fi
@@ -88,9 +92,6 @@ echoerr() { echo "$@" 1>&2; }
 #    echoerr "Usage: $0 <tagged_ard_version>"
 #    exit 1
 #fi
-
-# They can provide the version number as the first argument, otherwise we'll make a date-based one.
-version="${1:-$(date '+%Y%m%d-%H%M')}"
 
 package_name=ard-pipeline
 package_description="ARD Pipeline"

--- a/deployment/nci/create-module.sh
+++ b/deployment/nci/create-module.sh
@@ -1,5 +1,27 @@
 #!/usr/bin/env bash
 
+# ARD Pipeline Module Creation
+# ----------------------------
+
+# This provides a workflow to create a conda environment & install ard-pipeline,
+# typically on NCI systems (by default this script depends on NCI /g/data dirs &
+# PBS). The workflow is configurable with command line args & env variables:
+#
+# module_dir: specify a path to change the install location.
+# swfo_version: git commit ID (a type of version)
+# gost_version: DISABLED
+# modtran_version: currently unused
+#
+#
+# Usage examples
+# --------------
+#
+# Create environment in a custom dir:
+# $ module_dir=/g/data/users/person/modules ./deployment/nci/create-module.sh
+#
+# Create environment in a custom dir, with custom version:
+# $ module_dir=/g/data/users/person/modules ./deployment/nci/create-module.sh v1.0
+
 set -eou pipefail
 
 # Ensure `this_path` is an absolute path to prevent create-conda-environment.sh

--- a/deployment/nci/create-module.sh
+++ b/deployment/nci/create-module.sh
@@ -1,28 +1,49 @@
 #!/usr/bin/env bash
 
 # ARD Pipeline Module Creation
-# ----------------------------
-
-# This provides a workflow to create a conda environment & install ard-pipeline,
-# typically on NCI systems (by default this script depends on NCI /g/data dirs &
-# PBS). The workflow is configurable with command line args & env variables:
 #
-# module_dir: specify a path to change the install location.
-# swfo_version: git commit ID (a type of version)
-# gost_version: DISABLED
-# modtran_version: currently unused
-#
-#
-# Usage examples
-# --------------
-#
-# Create environment in a custom dir:
-# $ module_dir=/g/data/users/person/modules ./deployment/nci/create-module.sh
-#
-# Create environment in a custom dir, with custom version:
-# $ module_dir=/g/data/users/person/modules ./deployment/nci/create-module.sh v1.0
+# This provides a workflow to create a conda environment & install ard-pipeline.
 
 set -eou pipefail
+
+usage_text="
+ARD Pipeline Module Creation
+----------------------------
+
+Usage:
+    create-module.sh [version]
+
+Runs a workflow to create a conda environment & install ard-pipeline, typically
+on NCI systems (by default this script depends on NCI /g/data dirs & PBS).
+
+The workflow is configurable with command line args & env variables. A single
+command line argument exists 'version', which is the name of the directory
+where ard-pipeline will be installed. The following environment vars can be
+be overridden to customise dependencies:
+
+module_dir: specify a path to change the install location.
+swfo_version: git commit ID (a type of version)
+
+
+Usage examples:
+---------------
+
+Create environment in a custom directory:
+$ module_dir=/g/data/users/person/modules ./deployment/nci/create-module.sh
+
+Create environment in a custom dir, with custom version:
+$ module_dir=/g/data/users/person/modules ./deployment/nci/create-module.sh v1.0
+"
+
+if [ "$1" == "-h" ]; then
+  echo "$usage_text"
+  exit 0
+fi
+
+if [ "$1" == "--help" ]; then
+  echo "$usage_text"
+  exit 0
+fi
 
 # Ensure `this_path` is an absolute path to prevent create-conda-environment.sh
 # from failing further in the script due to a incorrect relative path

--- a/deployment/nci/create-module.sh
+++ b/deployment/nci/create-module.sh
@@ -2,7 +2,9 @@
 
 set -eou pipefail
 
-this_dir="$(dirname "${0}")"
+# Ensure `this_path` is an absolute path to prevent create-conda-environment.sh
+# from failing further in the script due to a incorrect relative path
+this_dir=$(realpath "$(dirname "${0}")")
 cd "${this_dir}"
 
 full_hostname=$(hostname)


### PR DESCRIPTION
Closes #70.

This PR covers these goals:
* Add help option to `deployment/nci/create-module.sh`
* Describe command line options for custom deployments
* Fix path handling so relative paths can be used

Result of testing these changes on `gadi`:
* Environment was created: PASS
* `check-environment` passed using the deployed module: PASS
* 350 unit tests ran, **36 failed**

There are some open questions in issue #70 which should be addressed in this review. Any comments welcome!