### PR TITLE
General cleanup of `geobox.py` & `test_geobox.py`

### DIFF
--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -22,16 +22,6 @@ affine.EPSILON = 1e-9
 affine.EPSILON2 = 1e-18
 
 
-# TODO: Flinders islet init is duplicated multiple times. Refactor to setUp() for
-#       test_real_world_origin...() & test_real_world_corner...() tests
-# TODO: this function currently unused
-def getFlindersIsletGGB():
-    flindersOrigin = (150.927659, -34.453309)
-    flindersCorner = (150.931697, -34.457915)
-
-    return GriddedGeoBox.from_corners(flindersOrigin, flindersCorner)
-
-
 # TODO: determine if "drv = None; ds = None" cleanup is required in some tests
 class TestGriddedGeoBox(unittest.TestCase):
     def test_create_shape(self):
@@ -96,61 +86,46 @@ class TestGriddedGeoBox(unittest.TestCase):
         ggb = GriddedGeoBox.from_corners(origin, corner)
         assert corner == ggb.corner
 
-    def test_real_world_shape(self):
-        # Flinders Islet, NSW
-        flindersOrigin = (150.927659, -34.453309)
-        flindersCorner = (150.931697, -34.457915)
-        shapeShouldBe = (19, 17)
 
-        ggb = GriddedGeoBox.from_corners(flindersOrigin, flindersCorner)
-        assert shapeShouldBe == ggb.shape
+class TestRealWorld(unittest.TestCase):
+    def setUp(self):
+        # Flinders Islet, NSW
+        self.flindersOrigin = (150.927659, -34.453309)
+        self.flindersCorner = (150.931697, -34.457915)
+        self.ggb = GriddedGeoBox.from_corners(self.flindersOrigin, self.flindersCorner)
+        self.shapeShouldBe = (19, 17)
+
+    def test_real_world_shape(self):
+        assert self.shapeShouldBe == self.ggb.shape
 
     def test_real_world_origin_lon(self):
-        # Flinders Islet, NSW
-        flindersOrigin = (150.927659, -34.453309)
-        flindersCorner = (150.931697, -34.457915)
-        originShouldBe = flindersOrigin
-        shapeShouldBe = (19, 17)
-
-        ggb = GriddedGeoBox.from_corners(flindersOrigin, flindersCorner)
-        assert shapeShouldBe == ggb.shape
-        self.assertAlmostEqual(originShouldBe[0], ggb.origin[0])
+        originShouldBe = self.flindersOrigin
+        assert self.shapeShouldBe == self.ggb.shape
+        self.assertAlmostEqual(originShouldBe[0], self.ggb.origin[0])
 
     def test_real_world_origin_lat(self):
-        # Flinders Islet, NSW
-        flindersOrigin = (150.927659, -34.453309)
-        flindersCorner = (150.931697, -34.457915)
-        originShouldBe = flindersOrigin
-
-        ggb = GriddedGeoBox.from_corners(flindersOrigin, flindersCorner)
-        self.assertAlmostEqual(originShouldBe[1], ggb.origin[1])
+        originShouldBe = self.flindersOrigin
+        self.assertAlmostEqual(originShouldBe[1], self.ggb.origin[1])
 
     def test_real_world_corner_lon(self):
-        # Flinders Islet, NSW
-        flindersOrigin = (150.927659, -34.453309)
-        flindersCorner = (150.931697, -34.457915)
-        shapeShouldBe = (19, 17)
         cornerShouldBe = (
-            flindersOrigin[0] + shapeShouldBe[1] * 0.00025,
-            flindersOrigin[1] - shapeShouldBe[0] * 0.00025,
+            self.flindersOrigin[0] + self.shapeShouldBe[1] * 0.00025,
+            self.flindersOrigin[1] - self.shapeShouldBe[0] * 0.00025,
         )
 
-        ggb = GriddedGeoBox.from_corners(flindersOrigin, flindersCorner)
-        self.assertAlmostEqual(cornerShouldBe[0], ggb.corner[0])
+        self.assertAlmostEqual(cornerShouldBe[0], self.ggb.corner[0])
 
     def test_real_world_corner_lat(self):
-        # Flinders Islet, NSW
-        flindersOrigin = (150.927659, -34.453309)
-        flindersCorner = (150.931697, -34.457915)
-        shapeShouldBe = (19, 17)
         cornerShouldBe = (
-            flindersOrigin[0] + shapeShouldBe[1] * 0.00025,
-            flindersOrigin[1] - shapeShouldBe[0] * 0.00025,
+            self.flindersOrigin[0] + self.shapeShouldBe[1] * 0.00025,
+            self.flindersOrigin[1] - self.shapeShouldBe[0] * 0.00025,
         )
 
-        ggb = GriddedGeoBox.from_corners(flindersOrigin, flindersCorner)
-        self.assertAlmostEqual(cornerShouldBe[1], ggb.corner[1])
+        self.assertAlmostEqual(cornerShouldBe[1], self.ggb.corner[1])
 
+
+# TODO: rename class
+class TestRemainder(unittest.TestCase):
     def test_ggb_transform_from_rio_dataset(self):
         img, geobox = ut.create_test_image()
         kwargs = {

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -183,36 +183,27 @@ class TestGeoboxGdalSpatialProperties(unittest.TestCase):
 
 
 class TestGeoboxH5SpatialProperties(unittest.TestCase):
-    def test_ggb_transform_from_h5_dataset(self):
-        img, geobox = ut.create_test_image()
-        with h5py.File("tmp.h5", "w", driver="core", backing_store=False) as fid:
-            ds = fid.create_dataset("test", data=img)
-            ds.attrs["geotransform"] = geobox.transform.to_gdal()
-            ds.attrs["crs_wkt"] = geobox.crs.ExportToWkt()
+    def setUp(self):
+        self.img, self.geobox = ut.create_test_image()
 
-            new_geobox = GriddedGeoBox.from_h5_dataset(ds)
-            assert new_geobox.transform == geobox.transform
+        with h5py.File("tmp.h5", "w", driver="core", backing_store=False) as fid:
+            ds = fid.create_dataset("test", data=self.img)
+            ds.attrs["geotransform"] = self.geobox.transform.to_gdal()
+            ds.attrs["crs_wkt"] = self.geobox.crs.ExportToWkt()
+
+            self.new_geobox = GriddedGeoBox.from_h5_dataset(ds)
+
+    def test_ggb_transform_from_h5_dataset(self):
+        assert self.new_geobox.transform == self.geobox.transform
 
     def test_ggb_crs_from_h5_dataset(self):
-        img, geobox = ut.create_test_image()
-        with h5py.File("tmp.h5", "w", driver="core", backing_store=False) as fid:
-            ds = fid.create_dataset("test", data=img)
-            ds.attrs["geotransform"] = geobox.transform.to_gdal()
-            ds.attrs["crs_wkt"] = geobox.crs.ExportToWkt()
-
-            new_geobox = GriddedGeoBox.from_h5_dataset(ds)
-            assert new_geobox.crs.ExportToWkt() == geobox.crs.ExportToWkt()
+        assert self.new_geobox.crs.ExportToWkt() == self.geobox.crs.ExportToWkt()
 
     def test_ggb_shape_from_h5_dataset(self):
-        img, geobox = ut.create_test_image()
-        with h5py.File("tmp.h5", "w", driver="core", backing_store=False) as fid:
-            ds = fid.create_dataset("test", data=img)
-            ds.attrs["geotransform"] = geobox.transform.to_gdal()
-            ds.attrs["crs_wkt"] = geobox.crs.ExportToWkt()
+        assert self.new_geobox.shape == self.img.shape
 
-            new_geobox = GriddedGeoBox.from_h5_dataset(ds)
-            assert new_geobox.shape == img.shape
 
+class TestCoordinates(unittest.TestCase):
     def test_convert_coordinate_to_map(self):
         """Test that an input image/array coordinate is correctly
         converted to a map coordinate.

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -294,8 +294,8 @@ class TestConversions(unittest.TestCase):
         origin = (669700, 6111700)
         ggb = GriddedGeoBox(shape, origin, crs="EPSG:32755")
 
-        lon = 148.862561
-        lat = -35.123064
+        exp_lon = 148.862561
+        exp_lat = -35.123064
         easting = 669717.105361586
         northing = 6111722.038508673
 
@@ -304,8 +304,8 @@ class TestConversions(unittest.TestCase):
 
         lon, lat = ggb.transform_coordinates((easting, northing), to_crs)
 
-        self.assertAlmostEqual(lon, 148.862561)
-        self.assertAlmostEqual(lat, -35.123064)
+        self.assertAlmostEqual(lon, exp_lon)
+        self.assertAlmostEqual(lat, exp_lat)
 
     # def test_pixelscale_metres(self):
     #     scale = 0.00025

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -124,59 +124,42 @@ class TestRealWorld(unittest.TestCase):
         self.assertAlmostEqual(cornerShouldBe[1], self.ggb.corner[1])
 
 
-# TODO: rename class
-class TestRemainder(unittest.TestCase):
-    def test_ggb_transform_from_rio_dataset(self):
-        img, geobox = ut.create_test_image()
-        kwargs = {
+class TestNewGeoboxSpatialProperties(unittest.TestCase):
+    """Ensure GriddedGeoBoxes from rasterio maintain spatial metadata."""
+
+    def setUp(self):
+        self.img, self.geobox = ut.create_test_image()
+        self.kwargs = {
             "driver": "MEM",
-            "width": img.shape[1],
-            "height": img.shape[0],
+            "width": self.img.shape[1],
+            "height": self.img.shape[0],
             "count": 1,
-            "transform": geobox.transform,
-            "crs": geobox.crs.ExportToWkt(),
-            "dtype": img.dtype.name,
+            "transform": self.geobox.transform,
+            "crs": self.geobox.crs.ExportToWkt(),
+            "dtype": self.img.dtype.name,
         }
 
-        with rio.open("tmp.tif", "w", **kwargs) as ds:
+    def test_ggb_transform_from_rio_dataset(self):
+        with rio.open("tmp.tif", "w", **self.kwargs) as ds:
             new_geobox = GriddedGeoBox.from_rio_dataset(ds)
 
-            assert new_geobox.transform == geobox.transform
+            assert new_geobox.transform == self.geobox.transform
 
     def test_ggb_crs_from_rio_dataset(self):
-        img, geobox = ut.create_test_image()
-        kwargs = {
-            "driver": "MEM",
-            "width": img.shape[1],
-            "height": img.shape[0],
-            "count": 1,
-            "transform": geobox.transform,
-            "crs": geobox.crs.ExportToWkt(),
-            "dtype": img.dtype.name,
-        }
-
-        with rio.open("tmp.tif", "w", **kwargs) as ds:
+        with rio.open("tmp.tif", "w", **self.kwargs) as ds:
             new_geobox = GriddedGeoBox.from_rio_dataset(ds)
 
-            assert new_geobox.crs.ExportToWkt() == geobox.crs.ExportToWkt()
+            assert new_geobox.crs.ExportToWkt() == self.geobox.crs.ExportToWkt()
 
     def test_ggb_shape_from_rio_dataset(self):
-        img, geobox = ut.create_test_image()
-        kwargs = {
-            "driver": "MEM",
-            "width": img.shape[1],
-            "height": img.shape[0],
-            "count": 1,
-            "transform": geobox.transform,
-            "crs": geobox.crs.ExportToWkt(),
-            "dtype": img.dtype.name,
-        }
-
-        with rio.open("tmp.tif", "w", **kwargs) as ds:
+        with rio.open("tmp.tif", "w", **self.kwargs) as ds:
             new_geobox = GriddedGeoBox.from_rio_dataset(ds)
 
-            assert new_geobox.shape == img.shape
+            assert new_geobox.shape == self.img.shape
 
+
+# TODO: rename
+class TestRemainder(unittest.TestCase):
     def test_ggb_transform_from_gdal_dataset(self):
         img, geobox = ut.create_test_image()
         drv = gdal.GetDriverByName("MEM")

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -6,6 +6,9 @@ import affine
 import h5py
 import numpy as np
 import numpy.testing as npt
+
+# FIXME: avoid importing both gdal & rasterio:
+#  https://rasterio.readthedocs.io/en/stable/topics/switch.html#mutual-incompatibilities
 import rasterio as rio
 from data import LS8_SCENE1
 from osgeo import gdal, osr
@@ -14,10 +17,14 @@ from wagl import unittesting_tools as ut
 from wagl.acquisition import acquisitions
 from wagl.geobox import GriddedGeoBox
 
+# TODO: use geobox module constants instead of redefining here?
 affine.EPSILON = 1e-9
 affine.EPSILON2 = 1e-18
 
 
+# TODO: Flinders islet init is duplicated multiple times. Refactor to setUp() for
+#       test_real_world_origin...() & test_real_world_corner...() tests
+# TODO: this function currently unused
 def getFlindersIsletGGB():
     flindersOrigin = (150.927659, -34.453309)
     flindersCorner = (150.931697, -34.457915)
@@ -25,6 +32,7 @@ def getFlindersIsletGGB():
     return GriddedGeoBox.from_corners(flindersOrigin, flindersCorner)
 
 
+# TODO: determine if "drv = None; ds = None" cleanup is required in some tests
 class TestGriddedGeoBox(unittest.TestCase):
     def test_create_shape(self):
         shape = (3, 2)
@@ -261,8 +269,8 @@ class TestGriddedGeoBox(unittest.TestCase):
             assert new_geobox.shape == img.shape
 
     def test_convert_coordinate_to_map(self):
-        """Test that an input image/array co-ordinate is correctly
-        converted to a map co-cordinate.
+        """Test that an input image/array coordinate is correctly
+        converted to a map coordinate.
         Simple case: The first pixel.
         """
         _, geobox = ut.create_test_image()
@@ -270,8 +278,8 @@ class TestGriddedGeoBox(unittest.TestCase):
         assert geobox.origin == (xmap, ymap)
 
     def test_convert_coordinate_to_image(self):
-        """Test that an input image/array co-ordinate is correctly
-        converted to a map co-cordinate.
+        """Test that an input image/array coordinate is correctly
+        converted to a map coordinate.
         Simple case: The first pixel.
         """
         _, geobox = ut.create_test_image()
@@ -279,14 +287,14 @@ class TestGriddedGeoBox(unittest.TestCase):
         assert (0, 0) == (ximg, yimg)
 
     def test_convert_coordinate_to_map_offset(self):
-        """Test that an input image/array co-ordinate is correctly
-        converted to a map co-cordinate using a pixel centre offset.
+        """Test that an input image/array coordinate is correctly
+        converted to a map coordinate using a pixel centre offset.
         Simple case: The first pixel.
         """
         _, geobox = ut.create_test_image()
         xmap, ymap = geobox.convert_coordinates((0, 0), centre=True)
 
-        # Get the actual centre co-ordinate of the first pixel
+        # Get the actual centre coordinate of the first pixel
         xcentre, ycentre = geobox.convert_coordinates((0.5, 0.5))
         assert (xcentre, ycentre) == (xmap, ymap)
 
@@ -301,7 +309,7 @@ class TestGriddedGeoBox(unittest.TestCase):
         ]
         truth = np.array(values)
 
-        # set up CRS; WGS84 Geographics
+        # set up CRS; WGS84 Geographic
         crs = osr.SpatialReference()
         crs.SetFromUserInput("EPSG:4326")
 

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -2,7 +2,6 @@
 
 import unittest
 
-import affine
 import h5py
 import numpy as np
 import numpy.testing as npt
@@ -17,77 +16,58 @@ from wagl import unittesting_tools as ut
 from wagl.acquisition import acquisitions
 from wagl.geobox import GriddedGeoBox
 
-# TODO: use geobox module constants instead of redefining here?
-affine.EPSILON = 1e-9
-affine.EPSILON2 = 1e-18
 
-
-# TODO: determine if "drv = None; ds = None" cleanup is required in some tests
 class TestGriddedGeoBox(unittest.TestCase):
+    def setUp(self):
+        self.shape = (3, 2)
+        self.origin = (150.0, -34.0)
+        self.ggb = GriddedGeoBox(self.shape, self.origin)
+
     def test_create_shape(self):
-        shape = (3, 2)
-        origin = (150.0, -34.0)
-        ggb = GriddedGeoBox(shape, origin)
-        assert shape == ggb.shape
+        assert self.shape == self.ggb.shape
 
     def test_get_shape_xy(self):
-        shape = (3, 2)
         shape_xy = (2, 3)
-        origin = (150.0, -34.0)
-        ggb = GriddedGeoBox(shape, origin)
-        assert shape_xy == ggb.get_shape_xy()
+        assert shape_xy == self.ggb.get_shape_xy()
 
     def test_get_shape_yx(self):
-        shape = (3, 2)
-        origin = (150.0, -34.0)
-        ggb = GriddedGeoBox(shape, origin)
-        assert shape == ggb.get_shape_yx()
+        assert self.shape == self.ggb.get_shape_yx()
 
     def test_x_size(self):
-        shape = (3, 2)
-        origin = (150.0, -34.0)
-        ggb = GriddedGeoBox(shape, origin)
-        assert shape[1] == ggb.x_size()
+        assert self.shape[1] == self.ggb.x_size()
 
     def test_y_size(self):
-        shape = (3, 2)
-        origin = (150.0, -34.0)
-        ggb = GriddedGeoBox(shape, origin)
-        assert shape[0] == ggb.y_size()
+        assert self.shape[0] == self.ggb.y_size()
 
     def test_create_origin(self):
-        shape = (3, 2)
-        origin = (150.0, -34.0)
-        ggb = GriddedGeoBox(shape, origin)
-        assert origin == ggb.origin
+        assert self.origin == self.ggb.origin
 
     def test_create_corner(self):
         scale = 0.00025
-        shape = (3, 2)
-        origin = (150.0, -34.0)
-        corner = (shape[1] * scale + origin[0], origin[1] - shape[0] * scale)
-        ggb = GriddedGeoBox(shape, origin)
-        assert corner == ggb.corner
+        corner = (
+            self.shape[1] * scale + self.origin[0],
+            self.origin[1] - self.shape[0] * scale,
+        )
+
+        assert corner == self.ggb.corner
 
     def test_shape_create_unit_GGB_using_corners(self):
         # create small GGB centred on (150.00025,-34.00025)
         expectedShape = (1, 1)
         scale = 0.00025
-        origin = (150.0, -34.0)
         corner = (150.0 + scale, -34.0 - scale)
-        ggb = GriddedGeoBox.from_corners(origin, corner)
+        ggb = GriddedGeoBox.from_corners(self.origin, corner)
         assert expectedShape == ggb.shape
 
     def test_corner_create_unit_GGB_using_corners(self):
         # create small GGB centred on (150.00025,-34.00025)
         scale = 0.00025
-        origin = (150.0, -34.0)
         corner = (150.0 + scale, -34.0 - scale)
-        ggb = GriddedGeoBox.from_corners(origin, corner)
+        ggb = GriddedGeoBox.from_corners(self.origin, corner)
         assert corner == ggb.corner
 
 
-class TestRealWorld(unittest.TestCase):
+class TestRealWorldSpatialProperties(unittest.TestCase):
     def setUp(self):
         # Flinders Islet, NSW
         self.flindersOrigin = (150.927659, -34.453309)

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -204,22 +204,23 @@ class TestGeoboxH5SpatialProperties(unittest.TestCase):
 
 
 class TestCoordinates(unittest.TestCase):
+    def setUp(self):
+        _, self.geobox = ut.create_test_image()
+
     def test_convert_coordinate_to_map(self):
         """Test that an input image/array coordinate is correctly
         converted to a map coordinate.
         Simple case: The first pixel.
         """
-        _, geobox = ut.create_test_image()
-        xmap, ymap = geobox.convert_coordinates((0, 0))
-        assert geobox.origin == (xmap, ymap)
+        xmap, ymap = self.geobox.convert_coordinates((0, 0))
+        assert self.geobox.origin == (xmap, ymap)
 
     def test_convert_coordinate_to_image(self):
         """Test that an input image/array coordinate is correctly
         converted to a map coordinate.
         Simple case: The first pixel.
         """
-        _, geobox = ut.create_test_image()
-        ximg, yimg = geobox.convert_coordinates(geobox.origin, to_map=False)
+        ximg, yimg = self.geobox.convert_coordinates(self.geobox.origin, to_map=False)
         assert (0, 0) == (ximg, yimg)
 
     def test_convert_coordinate_to_map_offset(self):
@@ -227,13 +228,14 @@ class TestCoordinates(unittest.TestCase):
         converted to a map coordinate using a pixel centre offset.
         Simple case: The first pixel.
         """
-        _, geobox = ut.create_test_image()
-        xmap, ymap = geobox.convert_coordinates((0, 0), centre=True)
+        xmap, ymap = self.geobox.convert_coordinates((0, 0), centre=True)
 
         # Get the actual centre coordinate of the first pixel
-        xcentre, ycentre = geobox.convert_coordinates((0.5, 0.5))
+        xcentre, ycentre = self.geobox.convert_coordinates((0.5, 0.5))
         assert (xcentre, ycentre) == (xmap, ymap)
 
+
+class TestConversions(unittest.TestCase):
     def test_project_extents(self):
         """Test that the geobox extents are correctly converted."""
         # values that have been pre-computed

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -158,44 +158,31 @@ class TestNewGeoboxSpatialProperties(unittest.TestCase):
             assert new_geobox.shape == self.img.shape
 
 
-# TODO: rename
-class TestRemainder(unittest.TestCase):
-    def test_ggb_transform_from_gdal_dataset(self):
-        img, geobox = ut.create_test_image()
-        drv = gdal.GetDriverByName("MEM")
-        ds = drv.Create("tmp.tif", img.shape[1], img.shape[0], 1, 1)
-        ds.SetGeoTransform(geobox.transform.to_gdal())
-        ds.SetProjection(geobox.crs.ExportToWkt())
+class TestGeoboxGdalSpatialProperties(unittest.TestCase):
+    def setUp(self):
+        self.img, self.geobox = ut.create_test_image()
+        self.drv = gdal.GetDriverByName("MEM")
+        self.ds = self.drv.Create("tmp.tif", self.img.shape[1], self.img.shape[0], 1, 1)
+        self.ds.SetGeoTransform(self.geobox.transform.to_gdal())
+        self.ds.SetProjection(self.geobox.crs.ExportToWkt())
 
-        new_geobox = GriddedGeoBox.from_gdal_dataset(ds)
-        assert new_geobox.transform == geobox.transform
-        drv = None
-        ds = None
+        self.new_geobox = GriddedGeoBox.from_gdal_dataset(self.ds)
+
+    def tearDown(self):
+        self.drv = None
+        self.ds = None
+
+    def test_ggb_transform_from_gdal_dataset(self):
+        assert self.new_geobox.transform == self.geobox.transform
 
     def test_ggb_crs_from_gdal_dataset(self):
-        img, geobox = ut.create_test_image()
-        drv = gdal.GetDriverByName("MEM")
-        ds = drv.Create("tmp.tif", img.shape[1], img.shape[0], 1, 1)
-        ds.SetGeoTransform(geobox.transform.to_gdal())
-        ds.SetProjection(geobox.crs.ExportToWkt())
-
-        new_geobox = GriddedGeoBox.from_gdal_dataset(ds)
-        assert new_geobox.crs.ExportToWkt() == geobox.crs.ExportToWkt()
-        drv = None
-        ds = None
+        assert self.new_geobox.crs.ExportToWkt() == self.geobox.crs.ExportToWkt()
 
     def test_ggb_shape_from_gdal_dataset(self):
-        img, geobox = ut.create_test_image()
-        drv = gdal.GetDriverByName("MEM")
-        ds = drv.Create("tmp.tif", img.shape[1], img.shape[0], 1, 1)
-        ds.SetGeoTransform(geobox.transform.to_gdal())
-        ds.SetProjection(geobox.crs.ExportToWkt())
+        assert self.new_geobox.shape == self.img.shape
 
-        new_geobox = GriddedGeoBox.from_gdal_dataset(ds)
-        assert new_geobox.shape == img.shape
-        drv = None
-        ds = None
 
+class TestGeoboxH5SpatialProperties(unittest.TestCase):
     def test_ggb_transform_from_h5_dataset(self):
         img, geobox = ut.create_test_image()
         with h5py.File("tmp.h5", "w", driver="core", backing_store=False) as fid:

--- a/wagl/geobox.py
+++ b/wagl/geobox.py
@@ -221,7 +221,7 @@ class GriddedGeoBox:
 
     def get_shape_xy(self):
         """Get the shape as a tuple (x,y)."""
-        return (self.shape[1], self.shape[0])
+        return self.shape[1], self.shape[0]
 
     def get_shape_yx(self):
         """Get the shape as a tuple (y,x)."""
@@ -230,7 +230,7 @@ class GriddedGeoBox:
     def transform_point(self, transformation, point):
         """Transform the point."""
         (x, y, _) = transformation.TransformPoint(point[0], point[1])
-        return (x, y)
+        return x, y
 
     def copy(self, crs="EPSG:4326"):
         """Create a copy of this GriddedGeoBox transformed to the supplied
@@ -287,7 +287,7 @@ class GriddedGeoBox:
         areaOriginXY = [int(math.floor(v)) for v in ~self.transform * originT]
         areaCornerXY = [int(math.ceil(v)) for v in ~self.transform * areaCornerT]
 
-        return ((areaOriginXY[1], areaCornerXY[1]), (areaOriginXY[0], areaCornerXY[0]))
+        return (areaOriginXY[1], areaCornerXY[1]), (areaOriginXY[0], areaCornerXY[0])
 
     def x_size(self):
         """The x-axis size."""
@@ -331,7 +331,7 @@ class GriddedGeoBox:
             inv = ~self.transform
             x, y = (int(v) for v in inv * xy)
 
-        return (x, y)
+        return x, y
 
     def transform_coordinates(self, xy, to_crs):
         """Transform a tuple co-ordinate pair (x, y) from one CRS to
@@ -361,7 +361,7 @@ class GriddedGeoBox:
 
         x, y = self.transform_point(transform, xy)
 
-        return (x, y)
+        return x, y
 
     def get_pixelsize_metres(self, xy=None):
         """Compute the size (in metres) of the pixel at the specified xy position.
@@ -402,7 +402,7 @@ class GriddedGeoBox:
             radians(lon2),
         )
 
-        return (x_size, y_size)
+        return x_size, y_size
 
     def get_all_pixelsize_metres(self):
         """Compute the size (in metres) of each pixel in this GriddedGeoBox. \
@@ -519,7 +519,7 @@ class GriddedGeoBox:
         """
         x = (self.ul[0] + self.ur[0] + self.lr[0] + self.ll[0]) / 4.0
         y = (self.ul[1] + self.ur[1] + self.lr[1] + self.ll[1]) / 4.0
-        return (x, y)
+        return x, y
 
     @property
     def ul_lonlat(self):

--- a/wagl/geobox.py
+++ b/wagl/geobox.py
@@ -23,7 +23,7 @@ affine.EPSILON2 = 1e-18
 
 
 # WGS84
-CRS = "EPSG:4326"
+CRS = "EPSG:4326"  # TODO: refactor varname to WGS84_CRS
 
 
 class GriddedGeoBox:
@@ -132,8 +132,8 @@ class GriddedGeoBox:
         return GriddedGeoBox(bbshape, origin, pixelsize, crs_wkt)
 
     @staticmethod
-    def from_corners(origin, corner, pixelsize=(0.00025, 0.00025), crs="EPSG:4326"):
-        """Return a GriddedGeoBox defined by the the two supplied
+    def from_corners(origin, corner, pixelsize=(0.00025, 0.00025), crs=CRS):
+        """Return a GriddedGeoBox defined by the two supplied
         corners.
 
         :param origin:
@@ -182,7 +182,7 @@ class GriddedGeoBox:
         shape=(1, 1),
         origin=(0.0, 0.0),
         pixelsize=(0.00025, 0.00025),
-        crs="EPSG:4326",
+        crs=CRS,
     ):
         """Create a new GriddedGeoBox.
 
@@ -232,7 +232,7 @@ class GriddedGeoBox:
         (x, y, _) = transformation.TransformPoint(point[0], point[1])
         return x, y
 
-    def copy(self, crs="EPSG:4326"):
+    def copy(self, crs=CRS):
         """Create a copy of this GriddedGeoBox transformed to the supplied
         Coordinate Reference System. The new GGB will have identical shape
         to the old and will be grid aligned to the new CRS. Pixel size

--- a/wagl/geobox.py
+++ b/wagl/geobox.py
@@ -28,7 +28,7 @@ CRS = "EPSG:4326"
 
 class GriddedGeoBox:
     """Represents a north up rectangular region on the Earth's surface which
-    has been divided into equal size retangular pixels for the purpose of
+    has been divided into equal size rectangular pixels for the purpose of
     data processing.
 
     The position and extent of the GriddedGeoBox on the Earth's
@@ -40,7 +40,7 @@ class GriddedGeoBox:
       - the shape of the GGB (yPixels, xPixels) where each value is
         a positive integer
 
-    Pixels within a GriddedGeoBox may be reference by their (x,y) grid
+    Pixels within a GriddedGeoBox may be referenced by their (x,y) grid
     position relative to the origin pixel in the upper (northwest) corner.
     x values increase to the east, y value increase to the south.
 
@@ -137,11 +137,11 @@ class GriddedGeoBox:
         corners.
 
         :param origin:
-            A tuple (in CRS coordinates) representing the positon of
+            A tuple (in CRS coordinates) representing the position of
             the NW corner of the GriddedGeoBox.
 
         :param corner:
-            A tuple (in CRS coordinates) representing the positon of
+            A tuple (in CRS coordinates) representing the position of
             the NW corner of the GriddedGeoBox.
 
         :param pixelsize:
@@ -192,7 +192,7 @@ class GriddedGeoBox:
             * Use get_shape_xy() to get (xSize, ySize).
 
         :param origin:
-            (xPos, yPos) 2-tuple difining the upper left GGB corner.
+            (xPos, yPos) 2-tuple defining the upper left GGB corner.
 
         :param pixelsize:
             Pixel (xSize, ySize) in CRS units.
@@ -234,7 +234,7 @@ class GriddedGeoBox:
 
     def copy(self, crs="EPSG:4326"):
         """Create a copy of this GriddedGeoBox transformed to the supplied
-        Coordinate Reference System. The new GGB will have idential shape
+        Coordinate Reference System. The new GGB will have identical shape
         to the old and will be grid aligned to the new CRS. Pixel size
         may change to accommodate the new CRS.
         """
@@ -268,11 +268,10 @@ class GriddedGeoBox:
         GriddedGeoBox which fully encloses the enclosed GGB.
 
         :param enclosedGGB:
-            A GGB which is a subset of this GGB and is fully enclosed
-            by it.
+            A GGB which is a subset of this GGB and is fully enclosed by it.
 
         :return:
-            A pair of range tuples defining the enclosed retangular subset
+            A pair of range tuples defining the enclosed rectangular subset
             ((row_start, row_stop), (col_start, col_stop)).
         """
         # transform to map enclosedGGB coords to self.crs coordinates
@@ -368,7 +367,7 @@ class GriddedGeoBox:
         """Compute the size (in metres) of the pixel at the specified xy position.
 
         :param xy:
-            A tuple containing an (x, y) grid co-ordinates of a pixel. Defaults \
+            A tuple containing an (x, y) grid co-ordinates of a pixel. Defaults
             to the central pixel in the grid.
 
         :return:

--- a/wagl/geobox.py
+++ b/wagl/geobox.py
@@ -7,6 +7,9 @@ import affine
 import geopandas
 import h5py
 import numpy as np
+
+# FIXME: avoid importing both gdal & rasterio:
+#  https://rasterio.readthedocs.io/en/stable/topics/switch.html#mutual-incompatibilities
 import rasterio as rio
 from affine import Affine
 from osgeo import gdal, osr
@@ -352,7 +355,7 @@ class GriddedGeoBox:
             err = err.format(type(to_crs))
             raise TypeError(err)
 
-        # ensure we using the traditional x, y axis ordering
+        # ensure we're using the traditional x, y axis ordering
         self.crs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
         to_crs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
 


### PR DESCRIPTION
This PR is a simple cleanup of `geobox.py` & `test_geobox.py` code & linting errors.

The main change is using `setUp()` & `tearDown()` methods to remove duplicated test data setup. This fixes remove ~75 lines of test code. I've left it as a `unittest` solution, instead of converting to `pytest` with fixtures (mainly to reduce the number of required external dependencies).