### PR TITLE
fix CopDEM tile NaN issue

### DIFF
--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -224,6 +224,7 @@ def read_copernicus_dem(cop_pathname, dst_geobox):
                 # possibly DEM tile not intersecting with the dst_geobox
                 pass
 
+    result = np.where(np.isnan(result), 0.0, result)
     return result
 
 


### PR DESCRIPTION
Replaces NaNs (absence of data, when CopDEM ocean tiles are missing because to land to report) with zeros in the DEM loading.