### PR TITLE
Config template update: LZF and timeouts

### DIFF
--- a/deployment/configs/landsat.cfg
+++ b/deployment/configs/landsat.cfg
@@ -12,7 +12,7 @@ dem_path = /ancillary/eoancillarydata-2/elevation/world_1deg/DEM_one_deg_20June2
 ecmwf_path = /empty
 invariant_height_fname = /ancillary/invariant/geo-potential-dem.tif
 h5_driver =
-compression = BITSHUFFLE
+compression = LZF
 
 [Package]
 yamls_dir =
@@ -60,6 +60,11 @@ state_path = luigi-state.pkl
 disable_hard_timeout = 50
 # Delay between task retries, container will set idle during this time
 retry_delay = 15
+
+[worker]
+
+# 90 minute default task timeout.
+timeout = 5400
 
 [task_history]
 db_connection = sqlite:///luigi-task-hist.db

--- a/deployment/configs/sentinel-2.cfg
+++ b/deployment/configs/sentinel-2.cfg
@@ -14,7 +14,7 @@ dem_path = /ancillary/eoancillarydata-2/elevation/world_1deg/DEM_one_deg_20June2
 ecmwf_path = /empty
 invariant_height_fname = /ancillary/invariant/geo-potential-dem.tif
 h5_driver =
-compression = BITSHUFFLE
+compression = LZF
 # rori = 0.52
 
 [Package]
@@ -66,6 +66,11 @@ state_path = luigi-state.pkl
 disable_hard_timeout = 50
 # Delay between task retries, container will set idle during this time
 retry_delay = 15
+
+[worker]
+
+# 90 minute default task timeout.
+timeout = 5400
 
 [task_history]
 db_connection = sqlite:///luigi-task-hist.db

--- a/deployment/nci/luigi.cfg.template
+++ b/deployment/nci/luigi.cfg.template
@@ -13,7 +13,7 @@ water_vapour = {"pathname": "/g/data/v10/eoancillarydata-2/water_vapour", "fallb
 dem_path = /g/data/v10/eoancillarydata-2/elevation/world_1deg/DEM_one_deg_20June2019.h5:/SRTM/GA-DSM
 ecmwf_path = /g/data2/v10/eoancillarydata-2/mars/daily-data
 invariant_height_fname = /g/data/v10/eoancillarydata-2/mars/daily-data/invariant/geo-potential-dem.tif
-compression = BITSHUFFLE
+compression = LZF
 h5_driver =
 
 [Package]
@@ -60,6 +60,11 @@ rpc_retry_attempts = 10
 rpc_retry_wait = 60
 logging_conf_file = ${package_dest}/etc/luigi-logging.cfg
 # max-reschedules = 1
+
+[worker]
+
+# 90 minute default task timeout.
+timeout = 5400
 
 [scheduler]
 record_task_history = true


### PR DESCRIPTION
To reflect what is working for us in production.

- We previously found reliability issues with bitshuffle, and the size difference versus lzf was not worth it.
- A default luigi task timeout stops the occasional job from running for hours with little progress.