### PR TITLE
Implement water body mask for tiled Copernicus DEM

### DIFF
--- a/wagl/ancillary.py
+++ b/wagl/ancillary.py
@@ -34,7 +34,7 @@ from wagl.constants import (
     WaterVapourTier,
 )
 from wagl.data import get_pixel, get_pixel_from_raster
-from wagl.dsm import copernicus_dem_images_for_latlon
+from wagl.dsm import copernicus_dem_image_for_latlon
 from wagl.hdf5 import (
     VLEN_STRING,
     H5CompressionFilter,
@@ -775,13 +775,14 @@ def get_elevation_data(lonlat: LonLat, pathname: PathWithDataset, offshore: bool
             metadata = {"id": np.array([md_uuid], VLEN_STRING)}
         else:
             if os.path.isdir(pathname):
-                imgs = copernicus_dem_images_for_latlon(
-                    pathname, [(floor(lonlat[1]), floor(lonlat[0]))]
+                img = os.path.join(
+                    pathname,
+                    copernicus_dem_image_for_latlon(floor(lonlat[1]), floor(lonlat[0])),
                 )
-                assert len(imgs) == 1
+
                 # TODO this assumes images on disk
                 # TODO support s3
-                data = get_pixel_from_raster(imgs[0], lonlat)
+                data = get_pixel_from_raster(img, lonlat)
             else:
                 data = get_pixel_from_raster(pathname, lonlat)
             metadata = {"id": np.array(["cop-30m-dem"], VLEN_STRING)}

--- a/wagl/brdf.py
+++ b/wagl/brdf.py
@@ -505,16 +505,7 @@ def wbm_to_ocean_mask(result):
     """
     Converts an image from water-body mask (enum of 0-3) to land-ocean mask (bool).
     """
-    OCEAN = 1
-    LAKE = 2
-    RIVER = 3
-    result = np.where(result == LAKE, OCEAN, result)
-    result = np.where(result == RIVER, OCEAN, result)
-
-    # only left with NO_WATER=0 and OCEAN=1
-    # mask as bool would be the inverted version
-    # (NO_WATER -> True, OCEAN -> False)
-    return (1 - result).astype(bool)
+    return result == 0  # 0 is land (no water)
 
 
 def only_ocean_pixels_tiled(src_poly, cop_pathname, src_geobox):

--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -111,17 +111,15 @@ def copernicus_folder_for_latlon(lat, lon) -> str:
     return f"Copernicus_DSM_COG_10_{lat_str}_00_{lon_str}_00_DEM"
 
 
-def copernicus_dem_images_for_latlon(
-    prefix: str, latlon: list[tuple[int, int]]
-) -> list[str]:
-    if prefix != "" and not prefix.endswith("/"):
-        prefix = prefix + "/"
+def copernicus_dem_image_for_latlon(lat, lon) -> str:
+    key_id = copernicus_folder_for_latlon(lat, lon)
+    return f"{key_id}/{key_id}.tif"
 
-    result = []
-    for lat, lon in latlon:
-        key_id = copernicus_folder_for_latlon(lat, lon)
-        result.append(f"{prefix}{key_id}/{key_id}.tif")
-    return result
+
+def copernicus_wbm_image_for_latlon(lat, lon) -> str:
+    key_id = copernicus_folder_for_latlon(lat, lon)
+    wbm_id = key_id.replace("_DEM", "_WBM")
+    return f"{key_id}/AUXFILES/{wbm_id}.tif"
 
 
 def split_s3_path_into_bucket_and_prefix(s3_path: str) -> tuple[str, str]:
@@ -142,7 +140,7 @@ def read_s3_object_into_memory(bucket, key):
         s3.download_fileobj(bucket, key, buffer)
         return buffer
     except s3.exceptions.NoSuchKey:
-        raise Exception(f"Failed to get cop30 DEM tile for s3://{bucket}/{key}")
+        raise FileNotFoundError(f"Failed to get cop30 DEM tile for s3://{bucket}/{key}")
 
 
 def covering_geobox_subset(dst_geobox, src_geobox):
@@ -163,6 +161,9 @@ def covering_geobox_subset(dst_geobox, src_geobox):
     maxx = min(ceil(max(p1[0], p2[0])), shape[1])
     maxy = min(ceil(max(p1[1], p2[1])), shape[0])
 
+    if (minx >= maxx) or (miny >= maxy):
+        return None, None
+
     subset_geobox = GriddedGeoBox(
         (maxy - miny, maxx - minx),
         origin=dst_geobox.transform * (minx, miny),
@@ -172,7 +173,11 @@ def covering_geobox_subset(dst_geobox, src_geobox):
     return (slice(miny, maxy), slice(minx, maxx)), subset_geobox
 
 
-def read_copernicus_dem(cop_pathname, dst_geobox):
+def list_copernicus_bands_for_geobox(cop_pathname, key_to_path, dst_geobox):
+    """
+    `key_to_path` is a function that takes a folder name and translates
+    it to a band path.
+    """
     if not os.path.isdir(cop_pathname) and not cop_pathname.startswith("s3://"):
         raise ValueError("Not a valid tiled Copernicus DEM")
 
@@ -184,13 +189,14 @@ def read_copernicus_dem(cop_pathname, dst_geobox):
     else:
         bucket, prefix = split_s3_path_into_bucket_and_prefix(cop_pathname)
 
+    if prefix != "" and not prefix.endswith("/"):
+        prefix = prefix + "/"
+
     latlon = copernicus_tiles_latlon_covering_geobox(dst_geobox)
-    sources = copernicus_dem_images_for_latlon(prefix, latlon)
 
-    result = np.full(dst_geobox.shape, np.nan, dtype=np.float32)
-    dst_crs = dst_geobox.crs.ExportToProj4()
+    for lat, lon in latlon:
+        location = prefix + key_to_path(lat, lon)
 
-    for location in sources:
         if cached:
             if not os.path.isfile(location):
                 # ocean tiles are not present
@@ -198,19 +204,31 @@ def read_copernicus_dem(cop_pathname, dst_geobox):
 
             dataset_reader = rasterio.open(location)
         else:
-            dataset_reader = read_s3_object_into_memory(bucket, location).open()
+            try:
+                dataset_reader = read_s3_object_into_memory(bucket, location).open()
+            except FileNotFoundError:
+                continue
 
+        yield dataset_reader
+
+
+def read_copernicus_dem(cop_pathname, dst_geobox):
+    result = np.full(dst_geobox.shape, np.nan, dtype=np.float32)
+    dst_crs = dst_geobox.crs.ExportToProj4()
+
+    for dataset_reader in list_copernicus_bands_for_geobox(
+        cop_pathname, copernicus_dem_image_for_latlon, dst_geobox
+    ):
         with dataset_reader as ds:
             subset, subset_geobox = covering_geobox_subset(
                 dst_geobox, GriddedGeoBox.from_dataset(ds)
             )
 
+            if subset is None:
+                continue
+
             try:
                 reprojected = np.full(subset_geobox.shape, np.nan, dtype=np.float32)
-
-                if not (reprojected.shape[0] > 0 and reprojected.shape[1] > 0):
-                    # otherwise reproject below fails
-                    raise ValueError
 
                 reproject(
                     source=rasterio.band(ds, 1),


### PR DESCRIPTION
For the tiled Copernicus 30m DEM arranged in folders, we can now set the ocean mask location (`ocean_mask_path` and `extended_ocean_mask_path` for the Australian mainland and the offshore territories respectively) to the root of the DEM folder. It will then use the water-body mask layer that comes with the DEM to mask BRDF data.