### PR TITLE
Fix metadata gen when zero valid s2cloudless pixels

### DIFF
--- a/eugl/metadata.py
+++ b/eugl/metadata.py
@@ -197,8 +197,13 @@ def s2cloudless_metadata(
     base_info = _get_s2cloudless_metadata()
 
     # info will be based on the valid pixels only (exclude 0)
-    # scaled probability density function
-    pdf = hist[1:] / hist[1:].sum() * 100
+    valid_pixel_count = hist[1:].sum()
+    if valid_pixel_count > 0:
+        # scaled probability density function
+        pdf = hist[1:] / valid_pixel_count * 100
+    else:
+        # No valid pixels: all zero
+        pdf = np.zeros_like(hist[1:])
 
     md = {
         "parameters": {


### PR DESCRIPTION
I'm assuming we want these represented as a zero count in the metadata, but please advise if you disagree!

```
    Example datasets:
      /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C/2022/2022-02/15S145E-20S150E/S2A_MSIL1C_20220227T002711_N0400_R016_T55KFU_20220227T015951.zip
      /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C/2022/2022-03/25S145E-30S150E/S2B_MSIL1C_20220301T002049_N0400_R116_T55JGM_20220301T012734.zip
      /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C/2022/2022-03/30S140E-35S145E/S2A_MSIL1C_20220309T002711_N0400_R016_T55HCE_20220309T020450.zip
      /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C/2022/2022-04/10S130E-15S135E/S2A_MSIL1C_20220409T013711_N0400_R031_T52LHL_20220409T030537.zip
      /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C/2022/2022-04/10S130E-15S135E/S2B_MSIL1C_20220401T012709_N0400_R131_T53LME_20220401T023611.zip
    Example Traceback:
        Traceback (most recent call last):
          File "/g/data/v10/private/modules/ard-pipeline/20250320-1158-s2/conda/lib/python3.11/site-packages/luigi/worker.py", line 210, in run
            new_deps = self._run_get_new_deps()
                       ^^^^^^^^^^^^^^^^^^^^^^^^
          File "/g/data/v10/private/modules/ard-pipeline/20250320-1158-s2/conda/lib/python3.11/site-packages/luigi/worker.py", line 138, in _run_get_new_deps
            task_gen = self.task.run()
                       ^^^^^^^^^^^^^^^
          File "/g/data/v10/private/modules/ard-pipeline/20250320-1158-s2/conda/lib/python3.11/site-packages/tesp/workflow.py", line 128, in run
            s2cl.s2cloudless_processing(
          File "/g/data/v10/private/modules/ard-pipeline/20250320-1158-s2/conda/lib/python3.11/site-packages/eugl/s2cl.py", line 211, in s2cloudless_processing
            s2cloudless_metadata(
          File "/g/data/v10/private/modules/ard-pipeline/20250320-1158-s2/conda/lib/python3.11/site-packages/eugl/metadata.py", line 201, in s2cloudless_metadata
            pdf = hist[1:] / hist[1:].sum() * 100
                  ~~~~~~~~~^~~~~~~~~~~~~~~~
        FloatingPointError: invalid value encountered in divide

```