### PR TITLE
Bug fix for tiling edge-case

### DIFF
--- a/tests/test_tiling.py
+++ b/tests/test_tiling.py
@@ -117,12 +117,12 @@ class TestGetTile3(unittest.TestCase):
             xstart, xend = xse
             assert 0 <= xstart < xend, "Tile empty - xcoord: " + repr(tile)
             assert 0 <= ystart < yend, "Tile empty - y coord: " + repr(tile)
-            assert xend - xstart <= xtile + xtol, ("Tile too big - x coord: " + repr(
+            assert xend - xstart <= xtile + xtol, "Tile too big - x coord: " + repr(
                 tile
-            ))
-            assert yend - ystart <= ytile + ytol, ("Tile too big - y coord: " + repr(
+            )
+            assert yend - ystart <= ytile + ytol, "Tile too big - y coord: " + repr(
                 tile
-            ))
+            )
 
     def check_tiling(self, samples, lines, tiles_list):
         """Check the tiles in tiles_list for covarge and overlap."""

--- a/wagl/acquisition/base.py
+++ b/wagl/acquisition/base.py
@@ -467,7 +467,7 @@ class Acquisition:
         Override as needed.
         """
 
-    def tiles(self):
+    def tiles(self, xtol=0, ytol=0):
         """Generate the tiling regime for this acquisition."""
         ysize, xsize = self.tile_size
-        return generate_tiles(self.samples, self.lines, xsize, ysize)
+        return generate_tiles(self.samples, self.lines, xsize, ysize, xtol, ytol)

--- a/wagl/reflectance.py
+++ b/wagl/reflectance.py
@@ -314,7 +314,7 @@ def calculate_reflectance(
     attach_image_attributes(nbart_dset, attrs)
 
     # process by tile
-    for tile in acquisition.tiles():
+    for tile in acquisition.tiles(xtol=1, ytol=1):
         # tile indices
         idx = (slice(tile[0][0], tile[0][1]), slice(tile[1][0], tile[1][1]))
 

--- a/wagl/satellite_solar_angles.py
+++ b/wagl/satellite_solar_angles.py
@@ -1102,7 +1102,7 @@ def calculate_angles(
     x_cent = np.zeros((acquisition.lines), dtype=out_dtype)
     n_cent = np.zeros((acquisition.lines), dtype=out_dtype)
 
-    for tile in acquisition.tiles():
+    for tile in acquisition.tiles(xtol=1, ytol=1):
         idx = (slice(tile[0][0], tile[0][1]), slice(tile[1][0], tile[1][1]))
 
         # read the lon and lat tile


### PR DESCRIPTION
For the usual tile size used of 256, when the image width is, for example, 15361 = 60 * 256 + 1, the last tile on the first row is of size (256, 1). That is, the image fed to the Fortran routine `satellite_angle` is 1 pixel wide.

In that routine there is an assumption that the image is at least 2 pixels wide:
```fortran
!       calculate pixel size (half)
        if (j .gt. 1) then
            delxx = (alon(i, j)-alon(i, j-1))/2
        else
            delxx = (alon(i, j+1)-alon(i, j))/2
        endif

```
and so `delxx` has invalid value and the error propagates onwards.

This PR fixes it by introducing tolerance for the tiling, with an `xtol=1` for example, the last tile is allowed to have width 257, despite the tile size being 256.

- [X] Closes https://github.com/OpenDataCubePipelines/ard-pipeline/issues/124