### PR TITLE
Fix CopDEM tile selection extents to correct DSM creation bug

### DIFF
--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -34,7 +34,7 @@ def l9_italy_extents():
 # Section: helper functions
 
 
-def get_lat_longs_from_coord_pairs(tuple_sequence):
+def get_unique_lat_longs_from_coord_pairs(tuple_sequence):
     """
     Split (lat, long) tuple sequence into separate latitude/longitude sequences.
     """
@@ -48,7 +48,7 @@ def get_lat_longs_from_coord_pairs(tuple_sequence):
 def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_extents):
     # Ensure CopDEM tile search provides correct coverage for Landsat scene extents
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
-    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
     assert latitudes == {-78, -77, -76, -75}
     assert longitudes == set(range(-120, -108))
@@ -56,7 +56,7 @@ def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_exte
 
 def test_calculate_latitude_extent_southern_hemisphere2(l9_buenos_aires_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_buenos_aires_extents)
-    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
     assert latitudes == {-34, -35, -36}
     assert longitudes == {-61, -60, -59, -58}
@@ -64,7 +64,7 @@ def test_calculate_latitude_extent_southern_hemisphere2(l9_buenos_aires_extents)
 
 def test_calculate_latitude_extent_northern_hemisphere(l9_italy_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_italy_extents)
-    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
     assert latitudes == {37, 38, 39}
     assert longitudes == {14, 15, 16, 17}

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -3,15 +3,24 @@ import pytest
 
 from wagl import dsm
 
+# Extents fixtures: these provide lat/long extents of several global Landsat
+# scenes. These are intended to cover northern/southern & east/west hemispheres.
+# Antarctic areas are also covered to include an area of polar extremes.
+
 
 @pytest.fixture
 def l9_antarctic_volcano_extents():
+    # Extents from LC09_L1GT_007114_20241215_20241215_02_T2.tar, converted from
+    # original to WGS84 CRS with `geobox.project_extents(wgs84_crs)`
+
     # order is min_x, min_y, max_x, max_y
     return -119.9633131, -77.2715533, -108.62444196, -74.51953282
 
 
 @pytest.fixture
 def l9_buenos_aires_extents():
+    # Extents converted from LC09_L1TP_225084_20241222_20241222_02_T1.tar
+
     # order is min_x, min_y, max_x, max_y
     return -60.05997761, -35.66956971, -57.50299335, -33.54584702
 
@@ -22,12 +31,22 @@ def l9_italy_extents():
     return 14.491808, 37.828106, 17.192353, 39.956304
 
 
+# Section: helper functions
+
+
 def get_lat_longs_from_coord_pairs(tuple_sequence):
+    """
+    Split (lat, long) tuple sequence into separate latitude/longitude sequences.
+    """
     latitudes, longitudes = zip(*tuple_sequence)
     return set(latitudes), set(longitudes)
 
 
+# Section: basic extents testing
+
+
 def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_extents):
+    # Ensure CopDEM tile search provides correct coverage for Landsat scene extents
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
     latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
 

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -31,6 +31,12 @@ def l9_italy_extents():
     return 14.491808, 37.828106, 17.192353, 39.956304
 
 
+@pytest.fixture
+def l5_wagga_extents():
+    # From LT05_L1TP_092084_20080925_20161029_01_T1.tar
+    return 145.434996, -35.581614, 148.077655, -33.653483
+
+
 # Section: helper functions
 
 
@@ -68,3 +74,12 @@ def test_lat_long_extents_northern_and_western_hemispheres(l9_italy_extents):
 
     assert latitudes == {37, 38, 39}
     assert longitudes == {14, 15, 16, 17}
+
+
+def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l5_wagga_extents)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
+
+    # these lat/long extents confirmed by loading CopDEM tiles in QGIS
+    assert latitudes == {-36, -35, -34}
+    assert longitudes == {145, 146, 147, 148}

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -83,3 +83,23 @@ def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):
     # these lat/long extents confirmed by loading CopDEM tiles in QGIS
     assert latitudes == {-36, -35, -34}
     assert longitudes == {145, 146, 147, 148}
+
+
+# Section: more detailed lat/long tests
+# confirm the exact (lat, long) extents pairs for covering tiles
+
+
+def test_eastern_hemisphere_lat_long_pairs(l5_wagga_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l5_wagga_extents)
+
+    for lat in (-36, -35, -34):
+        for long in (145, 146, 147, 148):
+            assert (lat, long) == gen.__next__()
+
+
+def test_western_hemisphere_lat_long_pairs(l9_antarctic_volcano_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
+
+    for lat in (-78, -77, -76, -75):
+        for long in range(-120, -108):
+            assert (lat, long) == gen.__next__()

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -37,6 +37,12 @@ def l5_wagga_extents():
     return 145.434996, -35.581614, 148.077655, -33.653483
 
 
+@pytest.fixture
+def l9_arizona_extents():
+    # from LC09_L1TP_037036_20241030_20241030_02_T1.tar
+    return -113.457772, 33.523343, -110.889247, 35.675949
+
+
 # Section: helper functions
 
 
@@ -74,6 +80,14 @@ def test_lat_long_extents_northern_and_eastern_hemispheres(l9_italy_extents):
 
     assert latitudes == {37, 38, 39}
     assert longitudes == {14, 15, 16, 17}
+
+
+def test_lat_long_extents_northern_and_western_hemispheres(l9_arizona_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_arizona_extents)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
+
+    assert latitudes == {33, 34, 35}
+    assert longitudes == {-114, -113, -112, -111}
 
 
 def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -1,0 +1,51 @@
+# Partial tests for the DSM/Digital Surface Model module
+import pytest
+
+from wagl import dsm
+
+
+@pytest.fixture
+def l9_antarctic_volcano_extents():
+    # order is min_x, min_y, max_x, max_y
+    return -119.9633131, -77.2715533, -108.62444196, -74.51953282
+
+
+@pytest.fixture
+def l9_buenos_aires_extents():
+    # order is min_x, min_y, max_x, max_y
+    return -60.05997761, -35.66956971, -57.50299335, -33.54584702
+
+
+@pytest.fixture
+def l9_italy_extents():
+    # from LC09_L1TP_188033_20231030_20231030_02_T1.tar
+    return 14.491808, 37.828106, 17.192353, 39.956304
+
+
+def get_lat_longs_from_coord_pairs(tuple_sequence):
+    latitudes, longitudes = zip(*tuple_sequence)
+    return set(latitudes), set(longitudes)
+
+
+def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
+    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+
+    assert latitudes == {-78, -77, -76, -75}
+    assert longitudes == set(range(-120, -108))
+
+
+def test_calculate_latitude_extent_southern_hemisphere2(l9_buenos_aires_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_buenos_aires_extents)
+    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+
+    assert latitudes == {-34, -35, -36}
+    assert longitudes == {-61, -60, -59, -58}
+
+
+def test_calculate_latitude_extent_northern_hemisphere(l9_italy_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_italy_extents)
+    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+
+    assert latitudes == {37, 38, 39}
+    assert longitudes == {14, 15, 16, 17}

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -45,7 +45,7 @@ def get_unique_lat_longs_from_coord_pairs(tuple_sequence):
 # Section: basic extents testing
 
 
-def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_extents):
+def test_lat_long_extents_southern_hemisphere_polar(l9_antarctic_volcano_extents):
     # Ensure CopDEM tile search provides correct coverage for Landsat scene extents
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
@@ -54,7 +54,7 @@ def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_exte
     assert longitudes == set(range(-120, -108))
 
 
-def test_calculate_latitude_extent_southern_hemisphere2(l9_buenos_aires_extents):
+def test_lat_long_extents_southern_and_western_hemispheres(l9_buenos_aires_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_buenos_aires_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
@@ -62,7 +62,7 @@ def test_calculate_latitude_extent_southern_hemisphere2(l9_buenos_aires_extents)
     assert longitudes == {-61, -60, -59, -58}
 
 
-def test_calculate_latitude_extent_northern_hemisphere(l9_italy_extents):
+def test_lat_long_extents_northern_and_western_hemispheres(l9_italy_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_italy_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -68,7 +68,7 @@ def test_lat_long_extents_southern_and_western_hemispheres(l9_buenos_aires_exten
     assert longitudes == {-61, -60, -59, -58}
 
 
-def test_lat_long_extents_northern_and_western_hemispheres(l9_italy_extents):
+def test_lat_long_extents_northern_and_eastern_hemispheres(l9_italy_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_italy_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -18,6 +18,12 @@ def l9_antarctic_volcano_extents():
 
 
 @pytest.fixture
+def l5_wagga_extents():
+    # From LT05_L1TP_092084_20080925_20161029_01_T1.tar
+    return 145.434996, -35.581614, 148.077655, -33.653483
+
+
+@pytest.fixture
 def l9_buenos_aires_extents():
     # Extents converted from LC09_L1TP_225084_20241222_20241222_02_T1.tar
 
@@ -29,12 +35,6 @@ def l9_buenos_aires_extents():
 def l9_italy_extents():
     # from LC09_L1TP_188033_20231030_20231030_02_T1.tar
     return 14.491808, 37.828106, 17.192353, 39.956304
-
-
-@pytest.fixture
-def l5_wagga_extents():
-    # From LT05_L1TP_092084_20080925_20161029_01_T1.tar
-    return 145.434996, -35.581614, 148.077655, -33.653483
 
 
 @pytest.fixture
@@ -66,6 +66,15 @@ def test_lat_long_extents_southern_hemisphere_polar(l9_antarctic_volcano_extents
     assert longitudes == set(range(-120, -108))
 
 
+def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l5_wagga_extents)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
+
+    # these lat/long extents confirmed by loading CopDEM tiles in QGIS
+    assert latitudes == {-36, -35, -34}
+    assert longitudes == {145, 146, 147, 148}
+
+
 def test_lat_long_extents_southern_and_western_hemispheres(l9_buenos_aires_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_buenos_aires_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
@@ -88,15 +97,6 @@ def test_lat_long_extents_northern_and_western_hemispheres(l9_arizona_extents):
 
     assert latitudes == {33, 34, 35}
     assert longitudes == {-114, -113, -112, -111}
-
-
-def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):
-    gen = dsm.copernicus_tiles_latlon_covering_geobox(l5_wagga_extents)
-    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
-
-    # these lat/long extents confirmed by loading CopDEM tiles in QGIS
-    assert latitudes == {-36, -35, -34}
-    assert longitudes == {145, 146, 147, 148}
 
 
 # Section: more detailed lat/long tests

--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -80,20 +80,11 @@ def copernicus_tiles_latlon_covering_geobox(geobox) -> list[tuple[int, int]]:
     cop30m_crs = osr.SpatialReference()
     cop30m_crs.ImportFromEPSG(4326)  # WGS84
 
-    origin = geobox.convert_coordinates((0, 0))
-    origin_lonlat = geobox.transform_coordinates(origin, cop30m_crs)
-    corner = geobox.convert_coordinates(geobox.get_shape_xy())
-    corner_lonlat = geobox.transform_coordinates(corner, cop30m_crs)
-
-    from_lat = floor(corner_lonlat[1])
-    to_lat = floor(origin_lonlat[1])
-    from_lon = floor(origin_lonlat[0])
-    to_lon = floor(corner_lonlat[0])
+    lat_lon_extents = geobox.project_extents(cop30m_crs)
+    from_lon, from_lat, to_lon, to_lat = (floor(n) for n in lat_lon_extents)
 
     def order(a, b):
-        if a <= b:
-            return a, b
-        return b, a
+        return (a, b) if a <= b else (b, a)
 
     from_lat, to_lat = order(from_lat, to_lat)
     from_lon, to_lon = order(from_lon, to_lon)
@@ -318,6 +309,7 @@ def get_dsm(
     dem_rows = shape[0] + margins.top + margins.bottom
     dem_shape = (dem_rows, dem_cols)
     dem_origin = geobox.convert_coordinates((0 - margins.left, 0 - margins.top))
+
     dem_geobox = GriddedGeoBox(
         dem_shape,
         origin=dem_origin,

--- a/wagl/standardise.py
+++ b/wagl/standardise.py
@@ -335,7 +335,7 @@ def stash_oa_bands(
 
         if workflow in (Workflow.STANDARD, Workflow.NBAR):
             # DEM
-            log.info("DEM-retriveal")
+            log.info("DEM-retrieval")
             get_dsm(
                 acqs[0],
                 srtm_pathname,


### PR DESCRIPTION
Fixes #125.

This change addresses several related elements:
* Modifies `copernicus_tiles_latlon_covering_geobox()` to ensure image extents for CopDEM are calculated for all corners of a scene. This corrects the missing/NODATA regions bug.
* Moves some CRS functionality into  `list_copernicus_bands_for_geobox()`. This simplifies the function signature of `copernicus_tiles_latlon_covering_geobox()` to simple data values, making it testable in isolation.
* Adds new unit tests for combinations of the eastern/western & northern/southern hemispheres. 
* Tidies/refactors `copernicus_tiles_latlon_covering_geobox()` to shrink the code with some Python features.

Any comments welcome...