### PR TITLE
fix psx, psy interpretation

### DIFF
--- a/wagl/f90_sources/compute_angles.f90
+++ b/wagl/f90_sources/compute_angles.f90
@@ -131,7 +131,7 @@ SUBROUTINE cal_angles(lam_p,phip_p,tol_lam,orb_elements,spheroid, &
     adiff = lam_p-lamcal
 
 !   if on the track easy - done and go back
-    if (abs(adiff) .lt. tol_lam) then
+    if (abs(adiff) .lt. abs(tol_lam)) then
         timet = t_p-t0
         theta_p = 0.0d0
         azimuth = 0.0d0

--- a/wagl/satellite_solar_angles.py
+++ b/wagl/satellite_solar_angles.py
@@ -943,11 +943,9 @@ def calculate_angles(
     longitude = lon_lat_group[DatasetName.LON.value]
     latitude = lon_lat_group[DatasetName.LAT.value]
 
-    # Determine approximate pixel size
-    lat_data = latitude[0:2, 0]
-    psy = abs(lat_data[1] - lat_data[0])
-    lon_data = longitude[0, 0:2]
-    psx = abs(lon_data[1] - lon_data[0])
+    # an arc second
+    psy = 1.0 / 3600
+    psx = 1.0 / 3600
 
     # Min and Max lat extents
     # This method should handle northern and southern hemispheres


### PR DESCRIPTION
The variables `psx` and `psy` are used in the code to calculate the ratio of the scale factors (named `hxy0` in the code) in the coordinate transformation from latitude/longitude to physical distances on Earth. The physical distance corresponding to a change in longitude for example depends on the latitude and therefore this ratio changes. For accuracy, in the code, we calculate the distances for an arc second of change (1/3600th of a degree), which is "small" enough.

But currently these variables are initialized to the conceptually similar idea of pixel size in the latitude/longitude coordinates. Over Antarctica the ratio deviates more from 1, and the error introduced by this bug is noticeable. Thanks @truth-quark for reporting it in https://github.com/OpenDataCubePipelines/ard-pipeline/issues/124. Fortunately, the impact over Australia is within our tolerance policy.

Additionally, the variable `tol_lam` which depends on pixel size in longitude may be negative for non-UTM projections, so better be on the safe size by taking the absolute value of it for comparison.

 