### PR TITLE
Integrate DE Ant DSM fixes into main ARD Pipeline

### DIFF
--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -34,7 +34,7 @@ def l9_italy_extents():
 # Section: helper functions
 
 
-def get_lat_longs_from_coord_pairs(tuple_sequence):
+def get_unique_lat_longs_from_coord_pairs(tuple_sequence):
     """
     Split (lat, long) tuple sequence into separate latitude/longitude sequences.
     """
@@ -48,7 +48,7 @@ def get_lat_longs_from_coord_pairs(tuple_sequence):
 def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_extents):
     # Ensure CopDEM tile search provides correct coverage for Landsat scene extents
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
-    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
     assert latitudes == {-78, -77, -76, -75}
     assert longitudes == set(range(-120, -108))
@@ -56,7 +56,7 @@ def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_exte
 
 def test_calculate_latitude_extent_southern_hemisphere2(l9_buenos_aires_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_buenos_aires_extents)
-    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
     assert latitudes == {-34, -35, -36}
     assert longitudes == {-61, -60, -59, -58}
@@ -64,7 +64,7 @@ def test_calculate_latitude_extent_southern_hemisphere2(l9_buenos_aires_extents)
 
 def test_calculate_latitude_extent_northern_hemisphere(l9_italy_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_italy_extents)
-    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
     assert latitudes == {37, 38, 39}
     assert longitudes == {14, 15, 16, 17}

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -3,15 +3,24 @@ import pytest
 
 from wagl import dsm
 
+# Extents fixtures: these provide lat/long extents of several global Landsat
+# scenes. These are intended to cover northern/southern & east/west hemispheres.
+# Antarctic areas are also covered to include an area of polar extremes.
+
 
 @pytest.fixture
 def l9_antarctic_volcano_extents():
+    # Extents from LC09_L1GT_007114_20241215_20241215_02_T2.tar, converted from
+    # original to WGS84 CRS with `geobox.project_extents(wgs84_crs)`
+
     # order is min_x, min_y, max_x, max_y
     return -119.9633131, -77.2715533, -108.62444196, -74.51953282
 
 
 @pytest.fixture
 def l9_buenos_aires_extents():
+    # Extents converted from LC09_L1TP_225084_20241222_20241222_02_T1.tar
+
     # order is min_x, min_y, max_x, max_y
     return -60.05997761, -35.66956971, -57.50299335, -33.54584702
 
@@ -22,12 +31,22 @@ def l9_italy_extents():
     return 14.491808, 37.828106, 17.192353, 39.956304
 
 
+# Section: helper functions
+
+
 def get_lat_longs_from_coord_pairs(tuple_sequence):
+    """
+    Split (lat, long) tuple sequence into separate latitude/longitude sequences.
+    """
     latitudes, longitudes = zip(*tuple_sequence)
     return set(latitudes), set(longitudes)
 
 
+# Section: basic extents testing
+
+
 def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_extents):
+    # Ensure CopDEM tile search provides correct coverage for Landsat scene extents
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
     latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
 

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -31,6 +31,12 @@ def l9_italy_extents():
     return 14.491808, 37.828106, 17.192353, 39.956304
 
 
+@pytest.fixture
+def l5_wagga_extents():
+    # From LT05_L1TP_092084_20080925_20161029_01_T1.tar
+    return 145.434996, -35.581614, 148.077655, -33.653483
+
+
 # Section: helper functions
 
 
@@ -68,3 +74,12 @@ def test_lat_long_extents_northern_and_western_hemispheres(l9_italy_extents):
 
     assert latitudes == {37, 38, 39}
     assert longitudes == {14, 15, 16, 17}
+
+
+def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l5_wagga_extents)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
+
+    # these lat/long extents confirmed by loading CopDEM tiles in QGIS
+    assert latitudes == {-36, -35, -34}
+    assert longitudes == {145, 146, 147, 148}

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -121,3 +121,46 @@ def test_western_hemisphere_lat_long_pairs(l9_antarctic_volcano_extents):
     for lat in (-78, -77, -76, -75):
         for long in range(-120, -108):
             assert (lat, long) == gen.__next__()
+
+
+# Section: equatorial crossing tests - ensure extents work over the equator
+
+
+def test_eastern_hemisphere_extents_crossing_equator():
+    # copy & shift Wagga scene extent latitudes north to mimic eastern hemisphere
+    # scene over the equator
+    min_long = 145.434996
+    min_lat = -35.581614 + 34.0
+    max_long = 148.077655
+    max_lat = -33.653483 + 35.0  # artificially extend by an extra degree
+
+    # ensure latitude range crosses equator
+    assert min_lat < 0
+    assert max_lat > 0
+
+    extents = (min_long, min_lat, max_long, max_lat)
+    gen = dsm.copernicus_tiles_latlon_covering_extents(extents)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
+
+    assert latitudes == {-2, -1, 0, 1}
+    assert longitudes == {145, 146, 147, 148}
+
+
+def test_western_hemisphere_extents_crossing_equator():
+    # copy & shift Buenos Aires scene extent latitudes north to mimic western
+    # hemisphere scene over the equator
+    min_long = -60.05997761
+    min_lat = -35.66956971 + 34.0
+    max_long = -57.50299335
+    max_lat = -33.54584702 + 35.0
+
+    # ensure latitude range crosses equator
+    assert min_lat < 0
+    assert max_lat > 0
+
+    extents = (min_long, min_lat, max_long, max_lat)
+    gen = dsm.copernicus_tiles_latlon_covering_extents(extents)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
+
+    assert latitudes == {-2, -1, 0, 1}
+    assert longitudes == {-61, -60, -59, -58}

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -83,3 +83,23 @@ def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):
     # these lat/long extents confirmed by loading CopDEM tiles in QGIS
     assert latitudes == {-36, -35, -34}
     assert longitudes == {145, 146, 147, 148}
+
+
+# Section: more detailed lat/long tests
+# confirm the exact (lat, long) extents pairs for covering tiles
+
+
+def test_eastern_hemisphere_lat_long_pairs(l5_wagga_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l5_wagga_extents)
+
+    for lat in (-36, -35, -34):
+        for long in (145, 146, 147, 148):
+            assert (lat, long) == gen.__next__()
+
+
+def test_western_hemisphere_lat_long_pairs(l9_antarctic_volcano_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
+
+    for lat in (-78, -77, -76, -75):
+        for long in range(-120, -108):
+            assert (lat, long) == gen.__next__()

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -37,6 +37,12 @@ def l5_wagga_extents():
     return 145.434996, -35.581614, 148.077655, -33.653483
 
 
+@pytest.fixture
+def l9_arizona_extents():
+    # from LC09_L1TP_037036_20241030_20241030_02_T1.tar
+    return -113.457772, 33.523343, -110.889247, 35.675949
+
+
 # Section: helper functions
 
 
@@ -74,6 +80,14 @@ def test_lat_long_extents_northern_and_eastern_hemispheres(l9_italy_extents):
 
     assert latitudes == {37, 38, 39}
     assert longitudes == {14, 15, 16, 17}
+
+
+def test_lat_long_extents_northern_and_western_hemispheres(l9_arizona_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_arizona_extents)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
+
+    assert latitudes == {33, 34, 35}
+    assert longitudes == {-114, -113, -112, -111}
 
 
 def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -226,8 +226,8 @@ def test_southern_hemisphere_extents_crossing_antimeridian():
     max_lat = -33.653483
 
     # partially ensure longitude range crosses antimeridian
-    assert min_long < 0
-    assert max_long > 0
+    assert min_long < 179
+    assert max_long > 179
 
     extents = (min_long, min_lat, max_long, max_lat)
     gen = dsm.copernicus_tiles_latlon_covering_extents(extents)

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -1,0 +1,51 @@
+# Partial tests for the DSM/Digital Surface Model module
+import pytest
+
+from wagl import dsm
+
+
+@pytest.fixture
+def l9_antarctic_volcano_extents():
+    # order is min_x, min_y, max_x, max_y
+    return -119.9633131, -77.2715533, -108.62444196, -74.51953282
+
+
+@pytest.fixture
+def l9_buenos_aires_extents():
+    # order is min_x, min_y, max_x, max_y
+    return -60.05997761, -35.66956971, -57.50299335, -33.54584702
+
+
+@pytest.fixture
+def l9_italy_extents():
+    # from LC09_L1TP_188033_20231030_20231030_02_T1.tar
+    return 14.491808, 37.828106, 17.192353, 39.956304
+
+
+def get_lat_longs_from_coord_pairs(tuple_sequence):
+    latitudes, longitudes = zip(*tuple_sequence)
+    return set(latitudes), set(longitudes)
+
+
+def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
+    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+
+    assert latitudes == {-78, -77, -76, -75}
+    assert longitudes == set(range(-120, -108))
+
+
+def test_calculate_latitude_extent_southern_hemisphere2(l9_buenos_aires_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_buenos_aires_extents)
+    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+
+    assert latitudes == {-34, -35, -36}
+    assert longitudes == {-61, -60, -59, -58}
+
+
+def test_calculate_latitude_extent_northern_hemisphere(l9_italy_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_italy_extents)
+    latitudes, longitudes = get_lat_longs_from_coord_pairs(gen)
+
+    assert latitudes == {37, 38, 39}
+    assert longitudes == {14, 15, 16, 17}

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -45,7 +45,7 @@ def get_unique_lat_longs_from_coord_pairs(tuple_sequence):
 # Section: basic extents testing
 
 
-def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_extents):
+def test_lat_long_extents_southern_hemisphere_polar(l9_antarctic_volcano_extents):
     # Ensure CopDEM tile search provides correct coverage for Landsat scene extents
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
@@ -54,7 +54,7 @@ def test_calculate_latitude_extent_southern_hemisphere(l9_antarctic_volcano_exte
     assert longitudes == set(range(-120, -108))
 
 
-def test_calculate_latitude_extent_southern_hemisphere2(l9_buenos_aires_extents):
+def test_lat_long_extents_southern_and_western_hemispheres(l9_buenos_aires_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_buenos_aires_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
@@ -62,7 +62,7 @@ def test_calculate_latitude_extent_southern_hemisphere2(l9_buenos_aires_extents)
     assert longitudes == {-61, -60, -59, -58}
 
 
-def test_calculate_latitude_extent_northern_hemisphere(l9_italy_extents):
+def test_lat_long_extents_northern_and_western_hemispheres(l9_italy_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_italy_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -57,17 +57,19 @@ def get_unique_lat_longs_from_coord_pairs(tuple_sequence):
 # Section: basic extents testing
 
 
-def test_lat_long_extents_southern_hemisphere_polar(l9_antarctic_volcano_extents):
+def test_copdem_lat_long_extents_southern_hemisphere_polar(
+    l9_antarctic_volcano_extents,
+):
     # Ensure CopDEM tile search provides correct coverage for Landsat scene extents
-    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
+    gen = dsm.copernicus_tiles_latlon_covering_extents(l9_antarctic_volcano_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
     assert latitudes == {-78, -77, -76, -75}
     assert longitudes == set(range(-120, -108))
 
 
-def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):
-    gen = dsm.copernicus_tiles_latlon_covering_geobox(l5_wagga_extents)
+def test_copdem_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_extents(l5_wagga_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
     # these lat/long extents confirmed by loading CopDEM tiles in QGIS
@@ -75,24 +77,26 @@ def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):
     assert longitudes == {145, 146, 147, 148}
 
 
-def test_lat_long_extents_southern_and_western_hemispheres(l9_buenos_aires_extents):
-    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_buenos_aires_extents)
+def test_copdem_lat_long_extents_southern_and_western_hemispheres(
+    l9_buenos_aires_extents,
+):
+    gen = dsm.copernicus_tiles_latlon_covering_extents(l9_buenos_aires_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
     assert latitudes == {-34, -35, -36}
     assert longitudes == {-61, -60, -59, -58}
 
 
-def test_lat_long_extents_northern_and_eastern_hemispheres(l9_italy_extents):
-    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_italy_extents)
+def test_copdem_lat_long_extents_northern_and_eastern_hemispheres(l9_italy_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_extents(l9_italy_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
     assert latitudes == {37, 38, 39}
     assert longitudes == {14, 15, 16, 17}
 
 
-def test_lat_long_extents_northern_and_western_hemispheres(l9_arizona_extents):
-    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_arizona_extents)
+def test_copdem_lat_long_extents_northern_and_western_hemispheres(l9_arizona_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_extents(l9_arizona_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 
     assert latitudes == {33, 34, 35}
@@ -104,7 +108,7 @@ def test_lat_long_extents_northern_and_western_hemispheres(l9_arizona_extents):
 
 
 def test_eastern_hemisphere_lat_long_pairs(l5_wagga_extents):
-    gen = dsm.copernicus_tiles_latlon_covering_geobox(l5_wagga_extents)
+    gen = dsm.copernicus_tiles_latlon_covering_extents(l5_wagga_extents)
 
     for lat in (-36, -35, -34):
         for long in (145, 146, 147, 148):
@@ -112,7 +116,7 @@ def test_eastern_hemisphere_lat_long_pairs(l5_wagga_extents):
 
 
 def test_western_hemisphere_lat_long_pairs(l9_antarctic_volcano_extents):
-    gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_antarctic_volcano_extents)
+    gen = dsm.copernicus_tiles_latlon_covering_extents(l9_antarctic_volcano_extents)
 
     for lat in (-78, -77, -76, -75):
         for long in range(-120, -108):

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -68,7 +68,7 @@ def test_lat_long_extents_southern_and_western_hemispheres(l9_buenos_aires_exten
     assert longitudes == {-61, -60, -59, -58}
 
 
-def test_lat_long_extents_northern_and_western_hemispheres(l9_italy_extents):
+def test_lat_long_extents_northern_and_eastern_hemispheres(l9_italy_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_italy_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
 

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -18,6 +18,12 @@ def l9_antarctic_volcano_extents():
 
 
 @pytest.fixture
+def l5_wagga_extents():
+    # From LT05_L1TP_092084_20080925_20161029_01_T1.tar
+    return 145.434996, -35.581614, 148.077655, -33.653483
+
+
+@pytest.fixture
 def l9_buenos_aires_extents():
     # Extents converted from LC09_L1TP_225084_20241222_20241222_02_T1.tar
 
@@ -29,12 +35,6 @@ def l9_buenos_aires_extents():
 def l9_italy_extents():
     # from LC09_L1TP_188033_20231030_20231030_02_T1.tar
     return 14.491808, 37.828106, 17.192353, 39.956304
-
-
-@pytest.fixture
-def l5_wagga_extents():
-    # From LT05_L1TP_092084_20080925_20161029_01_T1.tar
-    return 145.434996, -35.581614, 148.077655, -33.653483
 
 
 @pytest.fixture
@@ -66,6 +66,15 @@ def test_lat_long_extents_southern_hemisphere_polar(l9_antarctic_volcano_extents
     assert longitudes == set(range(-120, -108))
 
 
+def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):
+    gen = dsm.copernicus_tiles_latlon_covering_geobox(l5_wagga_extents)
+    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
+
+    # these lat/long extents confirmed by loading CopDEM tiles in QGIS
+    assert latitudes == {-36, -35, -34}
+    assert longitudes == {145, 146, 147, 148}
+
+
 def test_lat_long_extents_southern_and_western_hemispheres(l9_buenos_aires_extents):
     gen = dsm.copernicus_tiles_latlon_covering_geobox(l9_buenos_aires_extents)
     latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
@@ -88,15 +97,6 @@ def test_lat_long_extents_northern_and_western_hemispheres(l9_arizona_extents):
 
     assert latitudes == {33, 34, 35}
     assert longitudes == {-114, -113, -112, -111}
-
-
-def test_lat_long_extents_southern_and_eastern_hemispheres(l5_wagga_extents):
-    gen = dsm.copernicus_tiles_latlon_covering_geobox(l5_wagga_extents)
-    latitudes, longitudes = get_unique_lat_longs_from_coord_pairs(gen)
-
-    # these lat/long extents confirmed by loading CopDEM tiles in QGIS
-    assert latitudes == {-36, -35, -34}
-    assert longitudes == {145, 146, 147, 148}
 
 
 # Section: more detailed lat/long tests

--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -77,7 +77,7 @@ def read_subset_to_geobox(dsm_dataset, dem_geobox):
     return dsm_data
 
 
-def copernicus_tiles_latlon_covering_geobox(lat_lon_extents):
+def copernicus_tiles_latlon_covering_extents(lat_lon_extents):
     # NB: lat_lon_extents order is  (min_x, min_y, max_x, max_y)
     from_lon, from_lat, to_lon, to_lat = (floor(n) for n in lat_lon_extents)
 
@@ -183,7 +183,7 @@ def list_copernicus_bands_for_geobox(cop_pathname, key_to_path, dst_geobox):
     cop30m_crs.ImportFromEPSG(4326)  # WGS84
     lat_lon_extents = dst_geobox.project_extents(cop30m_crs)
 
-    for lat, lon in copernicus_tiles_latlon_covering_geobox(lat_lon_extents):
+    for lat, lon in copernicus_tiles_latlon_covering_extents(lat_lon_extents):
         location = prefix + key_to_path(lat, lon)
 
         if cached:

--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -107,7 +107,13 @@ def copernicus_tiles_latlon_covering_extents(lat_lon_extents):
     :param lat_lon_extents: (min_x, min_y, max_x, max_y) tuple
     """
     # Convert floating point extents to integer coords for CopDEM tile numbering
-    # TODO: describe subtle floor() logic for lat/longs
+    #
+    # Tile naming depends on the latitude/longitude floor operation. A latitude
+    # coordinate extent of N34.5 has floor(34.5) --> 34, mapping to the N34 tile
+    # with its extent covering 34 to 35 degrees.
+    #
+    # "Negative" coordinates are more subtle. A latitude coord extent of S33.5
+    # has floor(-33.5) --> -34, mapping to tile S34 (-33 to -34 degrees).
     from_lon, from_lat, to_lon, to_lat = (floor(n) for n in lat_lon_extents)
 
     def order(a, b):

--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -78,7 +78,36 @@ def read_subset_to_geobox(dsm_dataset, dem_geobox):
 
 
 def copernicus_tiles_latlon_covering_extents(lat_lon_extents):
-    # NB: lat_lon_extents order is  (min_x, min_y, max_x, max_y)
+    """
+    Yields (lat, long) tuples of CopDEM tile coordinates.
+
+    These coordinates correspond to the CopDEM tile numbering scheme & extents
+    for each tile. Tile extents vary by hemisphere.
+
+    e.g. partial `gdalinfo` output for Copernicus_DSM_COG_10_S34_00_E148_00_DEM.tif:
+    ...
+    Upper Left  ( 147.9998611, -32.9998611) --> (148, -33)
+    Lower Left  ( 147.9998611, -33.9998611) --> (148, -34)
+    Upper Right ( 148.9998611, -32.9998611) --> (149, -33)
+    Lower Right ( 148.9998611, -33.9998611) --> (149, -34)
+    ...
+    In the southern hemisphere, S34 tile latitude extents are -33 to -34 degrees.
+    The S34 tile includes the extent to 34 degrees.
+
+    For a northern hemisphere tile Copernicus_DSM_COG_10_N34_00_E125_00_DEM.tif:
+    ...
+    Upper Left  ( 124.9998611,  35.0001389) --> (125, 35)
+    Lower Left  ( 124.9998611,  34.0001389) --> (125, 34)
+    Upper Right ( 125.9998611,  35.0001389) --> (126, 35)
+    Lower Right ( 125.9998611,  34.0001389) --> (126, 34)
+    ...
+    The N34 tile latitude extents are 34 to 35 degrees. It's slightly different
+    to the southern hemisphere with the N34 tile extents >= 34 degrees.
+
+    :param lat_lon_extents: (min_x, min_y, max_x, max_y) tuple
+    """
+    # Convert floating point extents to integer coords for CopDEM tile numbering
+    # TODO: describe subtle floor() logic for lat/longs
     from_lon, from_lat, to_lon, to_lat = (floor(n) for n in lat_lon_extents)
 
     def order(a, b):

--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -80,20 +80,11 @@ def copernicus_tiles_latlon_covering_geobox(geobox) -> list[tuple[int, int]]:
     cop30m_crs = osr.SpatialReference()
     cop30m_crs.ImportFromEPSG(4326)  # WGS84
 
-    origin = geobox.convert_coordinates((0, 0))
-    origin_lonlat = geobox.transform_coordinates(origin, cop30m_crs)
-    corner = geobox.convert_coordinates(geobox.get_shape_xy())
-    corner_lonlat = geobox.transform_coordinates(corner, cop30m_crs)
-
-    from_lat = floor(corner_lonlat[1])
-    to_lat = floor(origin_lonlat[1])
-    from_lon = floor(origin_lonlat[0])
-    to_lon = floor(corner_lonlat[0])
+    lat_lon_extents = geobox.project_extents(cop30m_crs)
+    from_lon, from_lat, to_lon, to_lat = (floor(n) for n in lat_lon_extents)
 
     def order(a, b):
-        if a <= b:
-            return a, b
-        return b, a
+        return (a, b) if a <= b else (b, a)
 
     from_lat, to_lat = order(from_lat, to_lat)
     from_lon, to_lon = order(from_lon, to_lon)
@@ -318,6 +309,7 @@ def get_dsm(
     dem_rows = shape[0] + margins.top + margins.bottom
     dem_shape = (dem_rows, dem_cols)
     dem_origin = geobox.convert_coordinates((0 - margins.left, 0 - margins.top))
+
     dem_geobox = GriddedGeoBox(
         dem_shape,
         origin=dem_origin,

--- a/wagl/standardise.py
+++ b/wagl/standardise.py
@@ -321,7 +321,7 @@ def stash_oa_bands(
 
         if workflow in (Workflow.STANDARD, Workflow.NBAR):
             # DEM
-            log.info("DEM-retriveal")
+            log.info("DEM-retrieval")
             get_dsm(
                 acqs[0],
                 srtm_pathname,


### PR DESCRIPTION
This PR brings the DE Antarctica DSM changes to the main ARD Pipeline branch.

The changes are:
* Modify DSM code to correctly calculate tile extents at different locations across the earth.
* Adds DSM developer tests for the tiling solution.
* Incorporates anti-meridian handling for the tiling solution.

Running the DSM module across 5 Landsat Antarctic scenes produced this `EPSG:3031` overview:
<img width="1453" height="706" alt="Overview screenshot_2025-09-29_15-33-20" src="https://github.com/user-attachments/assets/3b5a7b15-4ee2-486a-850f-4304ee9e55ea" />
