### PR TITLE
Incorporate surface pressure sanity checks to DE Ant prototype

### DIFF
--- a/tests/test_era5.py
+++ b/tests/test_era5.py
@@ -638,3 +638,30 @@ def test_has_low_minimum_ozone_atm_cm():
 #     }  # use instead of OzoneDict which requires more imports
 #     tco3, _ = era5.get_ozone_data_user_override(ozone)
 #     assert tco3 == user_override
+
+
+# surface pressure sanity testing
+
+
+@pytest.fixture
+def sp_lat_long():
+    return "fake lat", "fake lon"
+
+
+def test_has_valid_surface_pressure(sp_lat_long):
+    for sp in range(50000, 80000, 10000):
+        era5.validate_surface_pressure(sp, sp_lat_long)
+
+
+def test_has_invalid_minimum_surface_pressure(sp_lat_long):
+    # Test in pascals, the raw unit read from NCI NetCDF files
+    for invalid in (-1.0, 0, 200.0, 5000.0, 40000.0):
+        with pytest.raises(NotImplementedError):
+            era5.validate_surface_pressure(invalid, sp_lat_long)
+
+
+def test_has_invalid_maximum_surface_pressure(sp_lat_long):
+    # Test in pascals, the raw unit read from NCI NetCDF files
+    for invalid in (110500.0, 111000.0):
+        with pytest.raises(NotImplementedError):
+            era5.validate_surface_pressure(invalid, sp_lat_long)

--- a/wagl/era5.py
+++ b/wagl/era5.py
@@ -47,6 +47,15 @@ TCO3_MINIMUM_ATM_CM = 0.0
 TCO3_MAXIMUM_ATM_CM = 700.0 / 1000  # convert Dobson units to ATM-CM
 TCO3_LOW_ATM_CM = 100.0 / 1000
 
+# Below are estimates of sane min/max surface pressure, based on advice & data
+# analysis. An Antarctic region of -60 to -90 degrees was sampled for min, mean
+# & max surface pressure for 2020 to early 2025, with results plotted here:
+# https://github.com/OpenDataCubePipelines/ard-pipeline/issues/113#issuecomment-3021722692
+SP_MINIMUM_PA = 45000.0
+SP_MAXIMUM_PA = 110000.0
+
+
+# Multi level pressure variables
 ERA5_PRESSURE_LEVELS_VARIABLES = ("r", "t", "z")
 
 # ERA5 single levels have a variable in the file name & sometimes a different
@@ -179,10 +188,40 @@ def profile_data_frame_workflow(
             ds_pressure_levels, ds_single_level, acquisition_datetime, lat_lon
         )
 
+        # TODO: rejig sanity check to reference the relevant file path to help
+        #  debug files containing strange values
+        validate_surface_pressure(single_level_values.surface_pressure, lat_lon)
+
         frame = build_profile_data_frame(
             pressure_levels_values, single_level_values, ecwmf_levels
         )
         yield frame
+
+
+def validate_surface_pressure(sp_pa, lat_lon):
+    # `sp_pa` is assumed to be a single value given workflow point sampling.
+    # ERA5 reanalysis data has 0.25 * 0.25 cells, indicating multi-pixel area
+    # sampling is not required.
+    #
+    # NB: skip NODATA & NaN checks as these values were not detected during
+    #  exploratory data analysis to understand ERA5's data characteristics. See
+    #  https://github.com/OpenDataCubePipelines/ard-pipeline/issues/113 for info
+
+    if sp_pa <= SP_MINIMUM_PA:
+        msg = (
+            f"Surface pressure data contains abnormal low pressure values at "
+            f"{lat_lon}. The DE Antarctica prototype has not determined handling "
+            f"requirements for this case yet."
+        )
+        raise NotImplementedError(msg)
+
+    if sp_pa > SP_MAXIMUM_PA:
+        msg = (
+            f"Surface pressure data contains abnormal high pressure values at "
+            f"{lat_lon}. The DE Antarctica prototype has not determined handling "
+            f"requirements for this case yet."
+        )
+        raise NotImplementedError(msg)
 
 
 # TODO: could refactor into workflow function
@@ -375,7 +414,7 @@ def build_profile_data_frame(
 
     profile_frame = pd.DataFrame(var_name_mapping)
 
-    # apply data scaling & corrections
+    # `sp` / surface_pressure is in Pascals, needs conversion hPa/hectopascals
     surface_pressure = single_level_values.surface_pressure / 100.0
     geopotential_height = scale_z_to_geopotential_height(
         single_level_values.geopotential


### PR DESCRIPTION
This PR includes work from July 2025 that wasn't merged (probably lost among other tasks). It is included here as part of repository clean up efforts.

The change includes a basic sanity check to ensure surface pressure values for ERA5 data are within a sensible range. Given the DE Ant work branch is a prototype without solid requirements, this change only provides _fail fast_  capabilities. This is intended to break `ARD pipeline` runs quickly & alert of data issues.

Elements to consider:
* [ ] Is the data range acceptable?
* [ ] Does this check the data "well enough" for a prototype?